### PR TITLE
remove explicit local variable assignment

### DIFF
--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -37,11 +37,10 @@ module Kubeclient
 
     def get_resource_name(entity)
       if @api_version == "v1beta1"
-        entity_name = entity.pluralize.camelize(:lower)
+        entity.pluralize.camelize(:lower)
       else
-        entity_name = entity.pluralize.downcase
+        entity.pluralize.downcase
       end
-      entity_name
     end
 
 


### PR DESCRIPTION
conditionals return a value in Ruby, so we can omit the explicit local
variable assignment.