### PR TITLE
add minimal support for labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Examples:
 <br>
 `pods = client.get_pods`
 <br>
+You can get entities which have specific labels by specifying input parameter named `labels`: <br>
+`pods = client.get_pods(labels: 'name=redis-master')` <br>
+You can specify multiple labels and that returns entities which have both labels:  <br>
+`pods = client.get_pods(labels: 'name=redis-master,app=redis')`
 
 2. Get a specific node (and respectively: get_service "service id" , get_pod "pod id" , get_replication_controller "rc id" )
 <br>

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -53,11 +53,13 @@ module Kubeclient
       raise KubeException.new(e.http_code, JSON.parse(e.response)['message'])
     end
 
-    def get_entities(entity_type)
-      # TODO: labels support
+    def get_entities(entity_type, options)
+      params = {}
+      params['labels'] = options[:labels] if options[:labels]
+
       # TODO: namespace support?
       response = handling_kube_exception do
-        rest_client[get_resource_name(entity_type)].get # nil, labels
+        rest_client[get_resource_name(entity_type)].get(params: params)
       end
 
       result = JSON.parse(response)
@@ -165,8 +167,8 @@ module Kubeclient
       entity_name_plural = entity_name.pluralize
 
       # get all entities of a type e.g. get_nodes, get_pods, etc.
-      define_method("get_#{entity_name_plural}") do
-        get_entities(entity_type)
+      define_method("get_#{entity_name_plural}") do |options = {}|
+        get_entities(entity_type, options)
       end
 
       # watch all entities of a type e.g. watch_nodes, watch_pods, etc.


### PR DESCRIPTION
This supports only for `get` verb such as `get_pods`, `get_replication_controllers` and so on.

The usage is like following:
```
client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta1'
pods = client.get_pods(labels: 'app=redis-master')
```