### PR TITLE
move dynamically defined classes under `Kubeclient`

### DIFF
--- a/lib/kubeclient/entity_list.rb
+++ b/lib/kubeclient/entity_list.rb
@@ -1,13 +1,15 @@
 require 'delegate'
 
 # Kubernetes Entity List
-class EntityList < DelegateClass(Array)
-  attr_reader :kind, :resourceVersion
+module Kubeclient
+  class EntityList < DelegateClass(Array)
+    attr_reader :kind, :resourceVersion
 
-  def initialize(kind, resource_version, list)
-    @kind = kind
-    # rubocop:disable Style/VariableName
-    @resourceVersion = resource_version
-    super(list)
+    def initialize(kind, resource_version, list)
+      @kind = kind
+      # rubocop:disable Style/VariableName
+      @resourceVersion = resource_version
+      super(list)
+    end
   end
 end

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -7,7 +7,7 @@ end
 # Kubernetes client entity tests
 class KubeClientTest < MiniTest::Test
   def test_json
-    our_object = Service.new
+    our_object = Kubeclient::Service.new
     our_object.foo = 'bar'
     our_object.nested = {}
     our_object.nested.again = {}
@@ -25,7 +25,7 @@ class KubeClientTest < MiniTest::Test
       .to_return(body: open_test_json_file('service_exception_b1.json'),
                  status: 409)
 
-    service = Service.new
+    service = Kubeclient::Service.new
     service.id = 'redisslave'
     service.port = 80
     service.container_port = 6379
@@ -54,8 +54,8 @@ class KubeClientTest < MiniTest::Test
     assert_instance_of(EntityList, services)
     assert_equal('Service', services.kind)
     assert_equal(2, services.size)
-    assert_instance_of(Service, services[0])
-    assert_instance_of(Service, services[1])
+    assert_instance_of(Kubeclient::Service, services[0])
+    assert_instance_of(Kubeclient::Service, services[1])
   end
 
   def test_empty_list
@@ -106,11 +106,11 @@ class KubeClientTest < MiniTest::Test
     assert_instance_of(EntityList, result['pod'])
     assert_instance_of(EntityList, result['event'])
     assert_instance_of(EntityList, result['namespace'])
-    assert_instance_of(Service, result['service'][0])
-    assert_instance_of(Node, result['node'][0])
-    assert_instance_of(Event, result['event'][0])
-    assert_instance_of(Endpoint, result['endpoint'][0])
-    assert_instance_of(Namespace, result['namespace'][0])
+    assert_instance_of(Kubeclient::Service, result['service'][0])
+    assert_instance_of(Kubeclient::Node, result['node'][0])
+    assert_instance_of(Kubeclient::Event, result['event'][0])
+    assert_instance_of(Kubeclient::Endpoint, result['endpoint'][0])
+    assert_instance_of(Kubeclient::Namespace, result['namespace'][0])
   end
 
   private

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -51,7 +51,7 @@ class KubeClientTest < MiniTest::Test
     services = client.get_services
 
     refute_empty(services)
-    assert_instance_of(EntityList, services)
+    assert_instance_of(Kubeclient::EntityList, services)
     assert_equal('Service', services.kind)
     assert_equal(2, services.size)
     assert_instance_of(Kubeclient::Service, services[0])
@@ -65,7 +65,7 @@ class KubeClientTest < MiniTest::Test
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta3'
     pods = client.get_pods
-    assert_instance_of(EntityList, pods)
+    assert_instance_of(Kubeclient::EntityList, pods)
     assert_equal(0, pods.size)
   end
 
@@ -100,12 +100,12 @@ class KubeClientTest < MiniTest::Test
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta1'
     result = client.all_entities
     assert_equal(7, result.keys.size)
-    assert_instance_of(EntityList, result['node'])
-    assert_instance_of(EntityList, result['service'])
-    assert_instance_of(EntityList, result['replication_controller'])
-    assert_instance_of(EntityList, result['pod'])
-    assert_instance_of(EntityList, result['event'])
-    assert_instance_of(EntityList, result['namespace'])
+    assert_instance_of(Kubeclient::EntityList, result['node'])
+    assert_instance_of(Kubeclient::EntityList, result['service'])
+    assert_instance_of(Kubeclient::EntityList, result['replication_controller'])
+    assert_instance_of(Kubeclient::EntityList, result['pod'])
+    assert_instance_of(Kubeclient::EntityList, result['event'])
+    assert_instance_of(Kubeclient::EntityList, result['namespace'])
     assert_instance_of(Kubeclient::Service, result['service'][0])
     assert_instance_of(Kubeclient::Node, result['node'][0])
     assert_instance_of(Kubeclient::Event, result['event'][0])

--- a/test/test_namespace.rb
+++ b/test/test_namespace.rb
@@ -10,7 +10,7 @@ class TestNamespace < MiniTest::Test
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta3'
     namespace = client.get_namespace 'staging'
 
-    assert_instance_of(Namespace, namespace)
+    assert_instance_of(Kubeclient::Namespace, namespace)
     assert_equal('e388bc10-c021-11e4-a514-3c970e4a436a', namespace.metadata.uid)
     assert_equal('staging', namespace.metadata.name)
     assert_equal('1168', namespace.metadata.resourceVersion)
@@ -18,7 +18,7 @@ class TestNamespace < MiniTest::Test
   end
 
   def test_delete_namespace_v1beta3
-    our_namespace = Namespace.new
+    our_namespace = Kubeclient::Namespace.new
     our_namespace.name = 'staging'
 
     stub_request(:delete, /\/namespaces/)

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -10,7 +10,7 @@ class TestNode < MiniTest::Test
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta1'
     node = client.get_node('127.0.0.1')
 
-    assert_instance_of(Node, node)
+    assert_instance_of(Kubeclient::Node, node)
     assert_respond_to(node, 'creationTimestamp')
     assert_respond_to(node, 'uid')
     assert_respond_to(node, 'id')
@@ -30,7 +30,7 @@ class TestNode < MiniTest::Test
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta3'
     node = client.get_node('127.0.0.1')
 
-    assert_instance_of(Node, node)
+    assert_instance_of(Kubeclient::Node, node)
 
     assert_equal('01018013-a231-11e4-a36b-3c970e4a436a', node.metadata.uid)
     assert_equal('127.0.0.1', node.metadata.name)

--- a/test/test_pod.rb
+++ b/test/test_pod.rb
@@ -10,7 +10,7 @@ class TestPod < MiniTest::Test
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta1'
     pod = client.get_pod 'redis-master-pod'
 
-    assert_instance_of(Pod, pod)
+    assert_instance_of(Kubeclient::Pod, pod)
     assert_equal('redis-master-pod', pod.id)
     assert_equal('redis-master',
                  pod.desiredState.manifest.containers[0]['name'])
@@ -24,7 +24,7 @@ class TestPod < MiniTest::Test
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta3'
     pod = client.get_pod 'redis-master-pod'
 
-    assert_instance_of(Pod, pod)
+    assert_instance_of(Kubeclient::Pod, pod)
     assert_equal('redis-master3', pod.metadata.name)
     assert_equal('dockerfile/redis', pod.spec.containers[0]['image'])
   end

--- a/test/test_replication_controller.rb
+++ b/test/test_replication_controller.rb
@@ -10,7 +10,7 @@ class TestReplicationController < MiniTest::Test
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta1'
     rc = client.get_replication_controller 'frontendController'
 
-    assert_instance_of(ReplicationController, rc)
+    assert_instance_of(Kubeclient::ReplicationController, rc)
     assert_equal('frontendController', rc.id)
     assert_equal('f4e5966c-8eb2-11e4-a6e7-3c970e4a436a', rc.uid)
     assert_equal('default', rc.namespace)
@@ -32,7 +32,7 @@ class TestReplicationController < MiniTest::Test
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta3'
     rc = client.get_replication_controller 'frontendController'
 
-    assert_instance_of(ReplicationController, rc)
+    assert_instance_of(Kubeclient::ReplicationController, rc)
     assert_equal('guestbook-controller', rc.metadata.name)
     assert_equal('c71aa4c0-a240-11e4-a265-3c970e4a436a', rc.metadata.uid)
     assert_equal('default', rc.metadata.namespace)

--- a/test/test_service.rb
+++ b/test/test_service.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 # Service entity tests
 class TestService < MiniTest::Test
   def test_get_from_json_v1
-    mock = Service.new(
+    mock = Kubeclient::Service.new(
       'kind' => 'Service',
       'id' => 'redis-service',
       'uid' => 'fb01a69c-8ae2-11e4-acc5-3c970e4a436a',
@@ -28,7 +28,7 @@ class TestService < MiniTest::Test
   end
 
   def test_construct_our_own_service
-    our_service = Service.new
+    our_service = Kubeclient::Service.new
     our_service.id = 'redis-service'
     our_service.port = 80
     our_service.protocol = 'TCP'
@@ -52,7 +52,7 @@ class TestService < MiniTest::Test
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta1'
     service = client.get_service 'redisslave'
 
-    assert_instance_of(Service, service)
+    assert_instance_of(Kubeclient::Service, service)
     # checking that creationTimestamp was renamed properly
     assert_equal('2014-12-28T17:37:21+02:00', service.creationTimestamp)
     assert_equal('6a022e83-8ea7-11e4-a6e7-3c970e4a436a', service.uid)
@@ -74,7 +74,7 @@ class TestService < MiniTest::Test
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta3'
     service = client.get_service 'redisslave'
 
-    assert_instance_of(Service, service)
+    assert_instance_of(Kubeclient::Service, service)
     # checking that creationTimestamp was renamed properly
     assert_equal('2015-01-22T14:20:05+02:00',
                  service.metadata.creationTimestamp)
@@ -90,7 +90,7 @@ class TestService < MiniTest::Test
   end
 
   def test_delete_service
-    our_service = Service.new
+    our_service = Kubeclient::Service.new
     our_service.id = 'redis-service'
     our_service.port = 80
     our_service.protocol = 'TCP'


### PR DESCRIPTION
We shouldn't define classes in the top level namespace, since other
people may want to use those names.  This patch moves dynamically
defined constants under `Kubeclient` so that the library is friently
with other code bases.