### PR TITLE
Add Kubeclient#api_valid?

### DIFF
--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -211,5 +211,10 @@ module Kubeclient
       end
       JSON.parse(response)
     end
+
+    def api_valid?
+      result = api
+      result.is_a?(Hash) && result['versions'].is_a?(Array)
+    end
   end
 end


### PR DESCRIPTION
~~@abonas Please review.  I built this on top of #47, so it includes your commit.  If you change anything in there I will have to rebase, but that's ok.  So, only need to review the second commit.~~

With Kubeclient having a simple `api_valid?` method, then I can call that directly in https://github.com/ManageIQ/manageiq/pull/2156 without any extra logic.  Also, that allows you to change the validation method if `.api` gets unwieldy or is invalid in the future.