### PR TITLE
Fixed name of label selector parameter

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -109,7 +109,7 @@ module Kubeclient
       def get_entities(entity_type, klass, options)
         params = {}
         if options[:label_selector]
-          params['label-selector'] = options[:label_selector]
+          params['labelSelector'] = options[:label_selector]
         end
 
         # TODO: namespace support?


### PR DESCRIPTION
The parameter name for the label selector for get entities is "labelSelector", not "label_selector".
See http://kubernetes.io/third_party/swagger-ui/#!/v1beta3/listPod