### PR TITLE
Send bearer token only on relevant instance

### DIFF
--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -32,6 +32,7 @@ module Kubeclient
     def initialize(uri, version = 'v1beta3')
       handle_uri(uri, '/api')
       @api_version = version
+      @headers = {}
       ssl_options
     end
 

--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -39,8 +39,8 @@ module Kubeclient
                              @options[:basic_auth_password]
         end
 
-        if @options[:bearer_token]
-          request['authorization'] = "Bearer #{@options[:bearer_token]}"
+        @options[:headers].each do |header, value|
+          request[header] = value
         end
         request
       end


### PR DESCRIPTION
Currently, when setting a new bearer token to a client instance, it affects
any living instance, and might break their authentication support.
This patch fixes that issue.
Fixes #84