### PR TITLE
Update KubeException to inherit StandardError

### DIFF
--- a/lib/kubeclient/kube_exception.rb
+++ b/lib/kubeclient/kube_exception.rb
@@ -1,5 +1,5 @@
 # Kubernetes HTTP Exceptions
-class KubeException < Exception
+class KubeException < StandardError
   attr_reader :error_code, :message
 
   def initialize(error_code, message)


### PR DESCRIPTION
Currently, KubeException inherits from Exception, which is bad because
the default "rescue" behaviour is to catch only exception which are
StandardException.