### PR TITLE
Add namespace support for get_entities

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -115,9 +115,9 @@ module Kubeclient
           params['params'] = { labelSelector: options[:label_selector] }
         end
 
-        # TODO: namespace support?
+        ns_prefix = build_namespace_prefix(options[:namespace])
         response = handle_exception do
-          rest_client[resource_name(entity_type)]
+          rest_client[ns_prefix + resource_name(entity_type)]
           .get(params.merge(@headers))
         end
 

--- a/test/json/entity_list_b3_mynamespace.json
+++ b/test/json/entity_list_b3_mynamespace.json
@@ -1,0 +1,74 @@
+{
+    "kind": "ServiceList",
+    "apiVersion": "v1beta3",
+    "metadata": {
+        "selfLink": "/api/v1beta3/namespaces/mynamespace/services",
+        "resourceVersion": "475878"
+    },
+    "items": [
+        {
+            "metadata": {
+                "name": "gateway",
+                "namespace": "mynamespace",
+                "selfLink": "/api/v1beta3/namespaces/mynamespace/services/gateway",
+                "uid": "81a1f96a-1a56-11e5-8483-025a3ef4da9b",
+                "resourceVersion": "473066",
+                "creationTimestamp": "2015-06-24T09:50:54Z",
+                "labels": {
+                    "name": "gateway"
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "protocol": "TCP",
+                        "port": 9000,
+                        "targetPort": 9000,
+                        "nodePort": 0
+                    }
+                ],
+                "selector": {
+                    "name": "gateway"
+                },
+                "portalIP": "10.245.32.237",
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "metadata": {
+                "name": "parks",
+                "namespace": "mynamespace",
+                "selfLink": "/api/v1beta3/namespaces/mynamespace/services/parks",
+                "uid": "81a6f80a-1a56-11e5-8483-025a3ef4da9b",
+                "resourceVersion": "473067",
+                "creationTimestamp": "2015-06-24T09:50:54Z",
+                "labels": {
+                    "name": "parks"
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "protocol": "TCP",
+                        "port": 9000,
+                        "targetPort": 9000,
+                        "nodePort": 0
+                    }
+                ],
+                "selector": {
+                    "name": "parks"
+                },
+                "portalIP": "10.245.172.243",
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        }
+    ]
+}

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -176,6 +176,26 @@ class KubeClientTest < MiniTest::Test
                      times: 1)
   end
 
+  def test_entity_list_with_namespace
+    stub_request(:get, %r{/services})
+      .to_return(body: open_test_json_file('entity_list_b3_mynamespace.json'),
+                 status: 200)
+
+    client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta3'
+    services = client.get_services(namespace: 'mynamespace')
+
+    refute_empty(services)
+    assert_instance_of(Kubeclient::Common::EntityList, services)
+    assert_equal('Service', services.kind)
+    assert_equal(2, services.size)
+    assert_instance_of(Kubeclient::Service, services[0])
+    assert_instance_of(Kubeclient::Service, services[1])
+
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1beta3/namespaces/mynamespace/services',
+                     times: 1)
+  end
+
   def test_empty_list
     stub_request(:get, %r{/pods})
       .to_return(body: open_test_json_file('empty_pod_list_b3.json'),


### PR DESCRIPTION
Hi @abonas, 

thank your for you Kubernetes Ruby API. This small change adds namespace support for entities. 

Tests and rubocop is fine after the change...

Cheers