### PR TITLE
Bugfix: update of a entity not working as the name is not read correctly

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -173,7 +173,7 @@ module Kubeclient
       end
 
       def update_entity(entity_type, entity_config)
-        name = entity_config.name
+        name = entity_config.metadata.name
         # to_hash should be called because of issue #9 in recursive open
         # struct
         hash = entity_config.to_hash

--- a/test/json/service_update_b3.json
+++ b/test/json/service_update_b3.json
@@ -1,0 +1,22 @@
+{
+   "status" : {},
+   "kind" : "Service",
+   "apiVersion" : "v1beta3",
+   "spec" : {
+      "ports" : [
+         {
+            "targetPort" : 80,
+            "nodePort" : 0,
+            "port" : 80,
+            "protocol" : "TCP"
+         }
+      ],
+      "portalIP" : "1.2.3.4"
+   },
+   "metadata" : {
+      "name" : "my_service",
+      "creationTimestamp" : null,
+      "namespace" : "default",
+      "resourceVersion" : "2"
+   }
+}

--- a/test/test_service.rb
+++ b/test/test_service.rb
@@ -109,4 +109,28 @@ class TestService < MiniTest::Test
                      'http://localhost:8080/api/v1beta3/namespaces/development/services/redis-slave',
                      times: 1)
   end
+
+  def test_update_service
+    entity = 'service'
+    object = Kubeclient::Service.new
+    name = 'my_service'
+    object.metadata = {
+      'name' => name
+    }
+
+    stub_request(:put, %r{/services/#{name}})\
+      .to_return(
+        body: open_test_json_file('service_update_b3.json'),
+        status: 200
+      )
+
+    client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta3'
+    client.update_entity entity, object
+
+    assert_requested(
+      :put,
+      "http://localhost:8080/api/v1beta3/services/#{name}",
+      times: 1
+    )
+  end
 end


### PR DESCRIPTION
When I retrieve an entitiy via get_entity method, I cannot update it, as the name in the url is empty. I tested a service with API v1beta3.

I fixed this behavior and tried to add tests for update_entity. 