### PR TITLE
Add Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Dependency Status](https://gemnasium.com/abonas/kubeclient.svg)](https://gemnasium.com/abonas/kubeclient)
 
 A Ruby client for Kubernetes REST api.
-The client supports GET, POST, PUT, DELETE on nodes, pods, services, replication controllers, namespaces and endpoints.
+The client supports GET, POST, PUT, DELETE on nodes, pods, secrets, services, replication controllers, namespaces and endpoints.
 The client currently supports Kubernetes REST api version v1beta3.
 
 ## Installation
@@ -118,7 +118,7 @@ client = Kubeclient::Client.new 'https://localhost:8443/api/' , 'v1beta3',
 ## Examples:
 
 #### Get all instances of a specific entity type
-Such as: `get_pods`, `get_services`, `get_nodes`, `get_replication_controllers`
+Such as: `get_pods`, `get_secrets`, `get_services`, `get_nodes`, `get_replication_controllers`
 
 ```ruby
 pods = client.get_pods
@@ -134,7 +134,7 @@ pods = client.get_pods(label_selector: 'name=redis-master,app=redis')
 ```
 
 #### Get a specific instance of an entity (by name)
-Such as: `get_service "service name"` , `get_pod "pod name"` , `get_replication_controller "rc name"`
+Such as: `get_service "service name"` , `get_pod "pod name"` , `get_replication_controller "rc name"`, `get_secret "secret name"`
 
 The GET request should include the namespace name, except for nodes and namespaces entities.
 
@@ -159,7 +159,7 @@ client.delete_service "redis-service"
 ```
 
 #### Create an entity
-For example: `create_pod pod_object`, `create_replication_controller rc_obj`
+For example: `create_pod pod_object`, `create_replication_controller rc_obj`, `create_secret secret_object`
 
 Input parameter - object of type `Service`, `Pod`, `ReplicationController`.
 
@@ -177,7 +177,7 @@ client.create_service service`
 ```
 
 #### Update an entity
-For example: `update_pod`, `update_service`, `update_replication_controller`
+For example: `update_pod`, `update_service`, `update_replication_controller`, `update_secret`
 
 Input parameter - object of type `Service`, `Pod`, `ReplicationController`
 
@@ -188,7 +188,7 @@ client.update_service service1
 ```
 
 #### Get all entities of all types : all_entities
-Returns a hash with 7 keys (node, service, pod, replication_controller, namespace, endpoint and event). Each key points to an EntityList of same type.
+Returns a hash with 8 keys (node, secret, service, pod, replication_controller, namespace, endpoint and event). Each key points to an EntityList of same type.
 
 This method is a convenience method instead of calling each entity's get method separately.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Querying with uid causes 404.
 
 #### Delete an entity (by name)
 
-For example: `delete_pod "pod name"` , `delete_replication_controller "rc name"`, `delete node "node name"`
+For example: `delete_pod "pod name"` , `delete_replication_controller "rc name"`, `delete_node "node name"`, `delete_secret "secret name"`
 
 Input parameter - name (string) specifying service name, pod name, replication controller name.
 ```ruby

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -19,7 +19,7 @@ module Kubeclient
     # manually on every new entity addition,
     # and especially since currently the class body is empty
     ENTITY_TYPES = %w(Pod Service ReplicationController Node Event Endpoint
-                      Namespace).map do |et|
+                      Namespace Secret).map do |et|
       clazz = Class.new(RecursiveOpenStruct) do
         def initialize(hash = nil, args = {})
           args.merge!(recurse_over_arrays: true)

--- a/test/json/created_secret.json
+++ b/test/json/created_secret.json
@@ -1,0 +1,16 @@
+{
+  "kind": "Secret",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "test-secret",
+    "namespace": "dev",
+    "selfLink": "/api/v1/namespaces/dev/secrets/test-secret",
+    "uid": "4e38a198-2bcb-11e5-a483-0e840567604d",
+    "resourceVersion": "245569",
+    "creationTimestamp": "2015-07-16T14:59:49Z"
+  },
+  "data": {
+    "super-secret": "Y2F0J3MgYXJlIGF3ZXNvbWUK"
+  },
+  "type": "Opaque"
+}

--- a/test/json/secret_list_b3.json
+++ b/test/json/secret_list_b3.json
@@ -1,0 +1,44 @@
+{
+  "kind": "SecretList",
+  "apiVersion":"v1beta3",
+  "metadata":{
+    "selfLink":"/api/v1beta3/secrets",
+    "resourceVersion":"256788"
+  },
+  "items": [
+  {
+    "metadata": {
+      "name":"default-token-my2pi",
+      "namespace":"default",
+      "selfLink":"/api/v1beta3/namespaces/default/secrets/default-token-my2pi",
+      "uid":"07b60654-2a65-11e5-a483-0e840567604d",
+      "resourceVersion":"11",
+      "creationTimestamp":"2015-07-14T20:15:11Z",
+      "annotations": {
+        "kubernetes.io/service-account.name":"default",
+        "kubernetes.io/service-account.uid":"07b350a0-2a65-11e5-a483-0e840567604d"
+      }
+    },
+    "data":{
+      "ca.crt":"Y2F0J3MgYXJlIGF3ZXNvbWUK",
+      "token":"Y2F0J3MgYXJlIGF3ZXNvbWUK"
+    },
+    "type":"kubernetes.io/service-account-token"
+  },
+  {
+    "metadata": {
+      "name": "test-secret",
+      "namespace": "dev",
+      "selfLink": "/api/v1beta3/namespaces/dev/secrets/test-secret",
+      "uid": "4e38a198-2bcb-11e5-a483-0e840567604d",
+      "resourceVersion": "245569",
+      "creationTimestamp": "2015-07-16T14:59:49Z"
+    },
+    "data": {
+      "super-secret": "Y2F0J3MgYXJlIGF3ZXNvbWUK"
+    },
+    "type": "Opaque"
+  }
+  ]
+}
+

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -215,9 +215,13 @@ class KubeClientTest < MiniTest::Test
       .to_return(body: open_test_json_file('namespace_list_b3.json'),
                  status: 200)
 
+    stub_request(:get, %r{/secrets})
+      .to_return(body: open_test_json_file('secret_list_b3.json'),
+                 status: 200)
+
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta3'
     result = client.all_entities
-    assert_equal(7, result.keys.size)
+    assert_equal(8, result.keys.size)
     assert_instance_of(Kubeclient::Common::EntityList, result['node'])
     assert_instance_of(Kubeclient::Common::EntityList, result['service'])
     assert_instance_of(Kubeclient::Common::EntityList,
@@ -225,11 +229,13 @@ class KubeClientTest < MiniTest::Test
     assert_instance_of(Kubeclient::Common::EntityList, result['pod'])
     assert_instance_of(Kubeclient::Common::EntityList, result['event'])
     assert_instance_of(Kubeclient::Common::EntityList, result['namespace'])
+    assert_instance_of(Kubeclient::Common::EntityList, result['secret'])
     assert_instance_of(Kubeclient::Service, result['service'][0])
     assert_instance_of(Kubeclient::Node, result['node'][0])
     assert_instance_of(Kubeclient::Event, result['event'][0])
     assert_instance_of(Kubeclient::Endpoint, result['endpoint'][0])
     assert_instance_of(Kubeclient::Namespace, result['namespace'][0])
+    assert_instance_of(Kubeclient::Secret, result['secret'][0])
   end
 
   def test_api_bearer_token_with_params_success

--- a/test/test_secret.rb
+++ b/test/test_secret.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+# Namespace entity tests
+class TestSecret < MiniTest::Test
+  def test_get_namespace_v1
+    stub_request(:get, %r{/secrets})
+      .to_return(body: open_test_json_file('secret.json'),
+                 status: 200)
+
+    client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
+    secret = client.get_secret 'secret'
+
+    assert_instance_of(Kubeclient::Secret, secret)
+    assert_equal('e388bc10-c021-11e4-a514-3c970e4a436a', namespace.metadata.uid)
+    assert_equal('staging', namespace.metadata.name)
+    assert_equal('v1', namespace.apiVersion)
+
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1/secrets/secret',
+                     times: 1)
+  end
+
+  def test_delete_namespace_v1
+
+    stub_request(:delete, %r{/namespaces})
+      .to_return(status: 200)
+
+    client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1beta3'
+    client.delete_namespace our_namespace.name
+
+    assert_requested(:delete,
+                     'http://localhost:8080/api/v1beta3/namespaces/staging',
+                     times: 1)
+  end
+
+  def test_create_namespace
+    stub_request(:post, %r{/namespaces})
+      .to_return(body: open_test_json_file('created_namespace_b3.json'),
+                 status: 201)
+
+    namespace = Kubeclient::Namespace.new
+    namespace.metadata = {}
+    namespace.metadata.name = 'development'
+
+    client = Kubeclient::Client.new 'http://localhost:8080/api/'
+    created_namespace = client.create_namespace namespace
+    assert_instance_of(Kubeclient::Namespace, created_namespace)
+    assert_equal(namespace.metadata.name, created_namespace.metadata.name)
+  end
+end


### PR DESCRIPTION
I added tests for secrets that are on v1, while the `get_all_entities` test still works with v1beta3. I'm happy to change them all to v1beta3 for consistency, but figured we'll probably be moving tests to v1 anyway.