### PR TITLE
client: add compatibility with more_core_extensions

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -157,7 +157,7 @@ module Kubeclient
         # struct
         hash = entity_config.to_hash
 
-        ns_prefix = build_namespace_prefix(entity_config.metadata.namespace)
+        ns_prefix = build_namespace_prefix(entity_config.metadata['table'][:namespace])
 
         # TODO: temporary solution to add "kind" and apiVersion to request
         # until this issue is solved
@@ -177,7 +177,7 @@ module Kubeclient
         # to_hash should be called because of issue #9 in recursive open
         # struct
         hash = entity_config.to_hash
-        ns_prefix = build_namespace_prefix(entity_config.metadata.namespace)
+        ns_prefix = build_namespace_prefix(entity_config.metadata['table'][:namespace])
         handle_exception do
           rest_client[ns_prefix + resource_name(entity_type) + "/#{name}"]
             .put(hash.to_json, @headers)


### PR DESCRIPTION
This patch adds the support to use kubeclient in applications that require more_core_extensions.
Since the attribute namespace is monkey patched by ObjectNamespace we're now forced to use the RecursiveOpenStruct table to retrieve the namespace value.
