### PR TITLE
Implement Client#get_pod_log and #watch_pod_log

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,30 @@ client.proxy_url('pod', 'podname', 5001, 'ns')
 ```
 
 
+#### Get the logs of a pod
+You can get the logs of a running pod:
+
+```ruby
+client.get_pod_log('pod-name', 'default')
+ => "Running...\nRunning...\nRunning...\n"
+```
+
+If that pod has more than one container, you must specify the container:
+
+```ruby
+client.get_pod_log('pod-name', 'default', container: 'ruby')
+ => "..."
+```
+
+You can also watch the logs of a pod to get a stream of data:
+
+```ruby
+watcher = client.watch_pod_log('pod-name', 'default', container: 'ruby')
+watcher.each do |line|
+  puts line
+end
+```
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,14 @@ client.get_pod_log('pod-name', 'default', container: 'ruby')
  => "..."
 ```
 
+If a container in a pod terminates, a new container is started, and you want to
+retrieve the logs of the dead container, you can pass in the `previous` option:
+
+```ruby
+client.get_pod_log('pod-name', 'default', previous: true)
+ => "..."
+```
+
 You can also watch the logs of a pod to get a stream of data:
 
 ```ruby

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -50,7 +50,7 @@ module Kubeclient
         json_error_msg = {}
       end
       err_message = json_error_msg['message'] || e.message
-      raise KubeException.new(e.http_code, err_message)
+      raise KubeException.new(e.http_code, err_message, e.response)
     end
 
     def handle_uri(uri, path)
@@ -135,20 +135,7 @@ module Kubeclient
         uri.query = URI.encode_www_form('resourceVersion' => resource_version)
       end
 
-      options = {
-        use_ssl: uri.scheme == 'https',
-        ca_file: @ssl_options[:ca_file],
-        # ruby Net::HTTP uses verify_mode instead of verify_ssl
-        # http://ruby-doc.org/stdlib-1.9.3/libdoc/net/http/rdoc/Net/HTTP.html
-        verify_mode: @ssl_options[:verify_ssl],
-        cert: @ssl_options[:client_cert],
-        key: @ssl_options[:client_key],
-        basic_auth_user: @auth_options[:username],
-        basic_auth_password: @auth_options[:password],
-        headers: @headers
-      }
-
-      Kubeclient::Common::WatchStream.new(uri, options)
+      Kubeclient::Common::WatchStream.new(uri, net_http_options(uri))
     end
 
     def get_entities(entity_type, klass, options = {})
@@ -253,6 +240,29 @@ module Kubeclient
       end
     end
 
+    def get_pod_log(pod_name, namespace = nil, container: nil, previous: false)
+      params = { params: {} }
+      params[:params][:previous] = true if previous
+      params[:params][:container] = container if container
+
+      ns = build_namespace_prefix(namespace || 'default')
+      handle_exception do
+        rest_client[ns + "pods/#{pod_name}/log"]
+          .get(params.merge(@headers))
+      end
+    end
+
+    def watch_pod_log(pod_name, namespace = nil, container: nil)
+      params = 'follow'
+      params += "&container=#{container}" if container
+
+      ns = build_namespace_prefix(namespace || 'default')
+      uri = @api_endpoint
+            .merge("#{@api_endpoint.path}/#{@api_version}/#{ns}/pods/#{pod_name}/log?#{params}")
+
+      Kubeclient::Common::WatchStream.new(uri, net_http_options(uri))
+    end
+
     def resource_name(entity_type)
       ClientMixin.pluralize_entity entity_type.downcase
     end
@@ -294,6 +304,28 @@ module Kubeclient
 
       msg = "Cannot read token file #{@auth_options[:bearer_token_file]}"
       fail ArgumentError, msg unless File.readable?(@auth_options[:bearer_token_file])
+    end
+
+    def net_http_options(uri)
+      options = {
+        basic_auth_user: @auth_options[:username],
+        basic_auth_password: @auth_options[:password],
+        headers: @headers
+      }
+
+      if uri.scheme == 'https'
+        options.merge!(
+          use_ssl: true,
+          ca_file: @ssl_options[:ca_file],
+          cert: @ssl_options[:client_cert],
+          key: @ssl_options[:client_key],
+          # ruby Net::HTTP uses verify_mode instead of verify_ssl
+          # http://ruby-doc.org/stdlib-1.9.3/libdoc/net/http/rdoc/Net/HTTP.html
+          verify_mode: @ssl_options[:verify_ssl]
+        )
+      end
+
+      options
     end
   end
 end

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -135,7 +135,7 @@ module Kubeclient
         uri.query = URI.encode_www_form('resourceVersion' => resource_version)
       end
 
-      Kubeclient::Common::WatchStream.new(uri, net_http_options(uri))
+      Kubeclient::Common::WatchStream.new(uri, net_http_options(uri), format: :json)
     end
 
     def get_entities(entity_type, klass, options = {})
@@ -240,27 +240,27 @@ module Kubeclient
       end
     end
 
-    def get_pod_log(pod_name, namespace = nil, container: nil, previous: false)
+    def get_pod_log(pod_name, namespace, container: nil, previous: false)
       params = { params: {} }
       params[:params][:previous] = true if previous
       params[:params][:container] = container if container
 
-      ns = build_namespace_prefix(namespace || 'default')
+      ns = build_namespace_prefix(namespace)
       handle_exception do
         rest_client[ns + "pods/#{pod_name}/log"]
           .get(params.merge(@headers))
       end
     end
 
-    def watch_pod_log(pod_name, namespace = nil, container: nil)
+    def watch_pod_log(pod_name, namespace, container: nil)
       params = 'follow'
       params += "&container=#{container}" if container
 
-      ns = build_namespace_prefix(namespace || 'default')
+      ns = build_namespace_prefix(namespace)
       uri = @api_endpoint
             .merge("#{@api_endpoint.path}/#{@api_version}/#{ns}/pods/#{pod_name}/log?#{params}")
 
-      Kubeclient::Common::WatchStream.new(uri, net_http_options(uri))
+      Kubeclient::Common::WatchStream.new(uri, net_http_options(uri), format: :text)
     end
 
     def resource_name(entity_type)

--- a/lib/kubeclient/kube_exception.rb
+++ b/lib/kubeclient/kube_exception.rb
@@ -1,10 +1,11 @@
 # Kubernetes HTTP Exceptions
 class KubeException < StandardError
-  attr_reader :error_code, :message
+  attr_reader :error_code, :message, :response
 
-  def initialize(error_code, message)
+  def initialize(error_code, message, response = nil)
     @error_code = error_code
     @message = message
+    @response = response
   end
 
   def to_s

--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -19,12 +19,13 @@ module Kubeclient
 
         @http.request(request) do |response|
           unless response.is_a? Net::HTTPSuccess
-            fail KubeException.new(response.code, response.message)
+            fail KubeException.new(response.code, response.message, response)
           end
+          is_json = response['Content-Type'] == 'application/json'
           response.read_body do |chunk|
             buffer << chunk
             while (line = buffer.slice!(/.+\n/))
-              yield WatchNotice.new(JSON.parse(line))
+              yield is_json ? WatchNotice.new(JSON.parse(line)) : line.chomp
             end
           end
         end

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -1,11 +1,7 @@
 require 'test_helper'
 
-def open_test_json_file(name)
-  File.new(File.join(File.dirname(__FILE__), 'json', name))
-end
-
-def open_test_text_file(name)
-  File.new(File.join(File.dirname(__FILE__), 'txt', name))
+def open_test_file(name)
+  File.new(File.join(File.dirname(__FILE__), name.split('.').last, name))
 end
 
 # Kubernetes client entity tests
@@ -48,7 +44,7 @@ class KubeClientTest < MiniTest::Test
 
   def test_exception
     stub_request(:post, %r{/services})
-      .to_return(body: open_test_json_file('namespace_exception.json'),
+      .to_return(body: open_test_file('namespace_exception.json'),
                  status: 409)
 
     service = Kubeclient::Service.new
@@ -73,7 +69,7 @@ class KubeClientTest < MiniTest::Test
 
   def test_api
     stub_request(:get, 'http://localhost:8080/api')
-      .to_return(status: 200, body: open_test_json_file('versions_list.json'))
+      .to_return(status: 200, body: open_test_file('versions_list.json'))
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     response = client.api
@@ -94,7 +90,7 @@ class KubeClientTest < MiniTest::Test
 
   def test_api_valid
     stub_request(:get, 'http://localhost:8080/api')
-      .to_return(status: 200, body: open_test_json_file('versions_list.json'))
+      .to_return(status: 200, body: open_test_file('versions_list.json'))
 
     args = ['http://localhost:8080/api/']
 
@@ -106,7 +102,7 @@ class KubeClientTest < MiniTest::Test
 
   def test_api_valid_with_invalid_version
     stub_request(:get, 'http://localhost:8080/api')
-      .to_return(status: 200, body: open_test_json_file('versions_list.json'))
+      .to_return(status: 200, body: open_test_file('versions_list.json'))
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'foobar1'
     refute client.api_valid?
@@ -146,7 +142,7 @@ class KubeClientTest < MiniTest::Test
 
   def test_nonjson_exception
     stub_request(:get, %r{/servic})
-      .to_return(body: open_test_json_file('service_illegal_json_404.json'),
+      .to_return(body: open_test_file('service_illegal_json_404.json'),
                  status: 404)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
@@ -162,7 +158,7 @@ class KubeClientTest < MiniTest::Test
 
   def test_entity_list
     stub_request(:get, %r{/services})
-      .to_return(body: open_test_json_file('entity_list.json'),
+      .to_return(body: open_test_file('entity_list.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
@@ -182,7 +178,7 @@ class KubeClientTest < MiniTest::Test
 
   def test_empty_list
     stub_request(:get, %r{/pods})
-      .to_return(body: open_test_json_file('empty_pod_list.json'),
+      .to_return(body: open_test_file('empty_pod_list.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
@@ -193,49 +189,49 @@ class KubeClientTest < MiniTest::Test
 
   def test_get_all
     stub_request(:get, %r{/services})
-      .to_return(body: open_test_json_file('service_list.json'),
+      .to_return(body: open_test_file('service_list.json'),
                  status: 200)
 
     stub_request(:get, %r{/pods})
-      .to_return(body: open_test_json_file('pod_list.json'),
+      .to_return(body: open_test_file('pod_list.json'),
                  status: 200)
 
     stub_request(:get, %r{/nodes})
-      .to_return(body: open_test_json_file('node_list.json'),
+      .to_return(body: open_test_file('node_list.json'),
                  status: 200)
 
     stub_request(:get, %r{/replicationcontrollers})
-      .to_return(body: open_test_json_file('replication_controller_list.json'), status: 200)
+      .to_return(body: open_test_file('replication_controller_list.json'), status: 200)
 
     stub_request(:get, %r{/events})
-      .to_return(body: open_test_json_file('event_list.json'), status: 200)
+      .to_return(body: open_test_file('event_list.json'), status: 200)
 
     stub_request(:get, %r{/endpoints})
-      .to_return(body: open_test_json_file('endpoint_list.json'),
+      .to_return(body: open_test_file('endpoint_list.json'),
                  status: 200)
 
     stub_request(:get, %r{/namespaces})
-      .to_return(body: open_test_json_file('namespace_list.json'),
+      .to_return(body: open_test_file('namespace_list.json'),
                  status: 200)
 
     stub_request(:get, %r{/secrets})
-      .to_return(body: open_test_json_file('secret_list.json'),
+      .to_return(body: open_test_file('secret_list.json'),
                  status: 200)
 
     stub_request(:get, %r{/resourcequotas})
-      .to_return(body: open_test_json_file('resource_quota_list.json'),
+      .to_return(body: open_test_file('resource_quota_list.json'),
                  status: 200)
 
     stub_request(:get, %r{/limitranges})
-      .to_return(body: open_test_json_file('limit_range_list.json'),
+      .to_return(body: open_test_file('limit_range_list.json'),
                  status: 200)
 
     stub_request(:get, %r{/persistentvolumes})
-      .to_return(body: open_test_json_file('persistent_volume_list.json'),
+      .to_return(body: open_test_file('persistent_volume_list.json'),
                  status: 200)
 
     stub_request(:get, %r{/persistentvolumeclaims})
-      .to_return(body: open_test_json_file('persistent_volume_claim_list.json'),
+      .to_return(body: open_test_file('persistent_volume_claim_list.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
@@ -264,7 +260,7 @@ class KubeClientTest < MiniTest::Test
   def test_api_bearer_token_with_params_success
     stub_request(:get, 'http://localhost:8080/api/v1/pods?labelSelector=name=redis-master')
       .with(headers: { Authorization: 'Bearer valid_token' })
-      .to_return(body: open_test_json_file('pod_list.json'),
+      .to_return(body: open_test_file('pod_list.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/',
@@ -281,7 +277,7 @@ class KubeClientTest < MiniTest::Test
   def test_api_bearer_token_success
     stub_request(:get, 'http://localhost:8080/api/v1/pods')
       .with(headers: { Authorization: 'Bearer valid_token' })
-      .to_return(body: open_test_json_file('pod_list.json'),
+      .to_return(body: open_test_file('pod_list.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/',
@@ -315,7 +311,7 @@ class KubeClientTest < MiniTest::Test
 
   def test_api_basic_auth_success
     stub_request(:get, 'http://username:password@localhost:8080/api/v1/pods')
-      .to_return(body: open_test_json_file('pod_list.json'),
+      .to_return(body: open_test_file('pod_list.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/',
@@ -335,7 +331,7 @@ class KubeClientTest < MiniTest::Test
 
   def test_api_basic_auth_back_comp_success
     stub_request(:get, 'http://username:password@localhost:8080/api/v1/pods')
-      .to_return(body: open_test_json_file('pod_list.json'),
+      .to_return(body: open_test_file('pod_list.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/',
@@ -448,7 +444,7 @@ class KubeClientTest < MiniTest::Test
   def test_api_bearer_token_file_success
     stub_request(:get, 'http://localhost:8080/api/v1/pods')
       .with(headers: { Authorization: 'Bearer valid_token' })
-      .to_return(body: open_test_json_file('pod_list.json'),
+      .to_return(body: open_test_file('pod_list.json'),
                  status: 200)
 
     file = File.join(File.dirname(__FILE__), 'valid_token_file')
@@ -497,7 +493,7 @@ class KubeClientTest < MiniTest::Test
   def test_nil_items
     # handle https://github.com/kubernetes/kubernetes/issues/13096
     stub_request(:get, %r{/persistentvolumeclaims})
-      .to_return(body: open_test_json_file('persistent_volume_claims_nil_items.json'),
+      .to_return(body: open_test_file('persistent_volume_claims_nil_items.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -4,6 +4,10 @@ def open_test_json_file(name)
   File.new(File.join(File.dirname(__FILE__), 'json', name))
 end
 
+def open_test_text_file(name)
+  File.new(File.join(File.dirname(__FILE__), 'txt', name))
+end
+
 # Kubernetes client entity tests
 class KubeClientTest < MiniTest::Test
   def test_json

--- a/test/test_limit_range.rb
+++ b/test/test_limit_range.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class TestLimitRange < MiniTest::Test
   def test_get_from_json_v1
     stub_request(:get, %r{/limitranges})
-      .to_return(body: open_test_json_file('limit_range.json'),
+      .to_return(body: open_test_file('limit_range.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'

--- a/test/test_namespace.rb
+++ b/test/test_namespace.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class TestNamespace < MiniTest::Test
   def test_get_namespace_v1
     stub_request(:get, %r{/namespaces})
-      .to_return(body: open_test_json_file('namespace.json'),
+      .to_return(body: open_test_file('namespace.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
@@ -38,7 +38,7 @@ class TestNamespace < MiniTest::Test
 
   def test_create_namespace
     stub_request(:post, %r{/namespaces})
-      .to_return(body: open_test_json_file('created_namespace.json'),
+      .to_return(body: open_test_file('created_namespace.json'),
                  status: 201)
 
     namespace = Kubeclient::Namespace.new

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class TestNode < MiniTest::Test
   def test_get_from_json_v1
     stub_request(:get, %r{/nodes})
-      .to_return(body: open_test_json_file('node.json'),
+      .to_return(body: open_test_file('node.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'

--- a/test/test_persistent_volume.rb
+++ b/test/test_persistent_volume.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class TestPersistentVolume < MiniTest::Test
   def test_get_from_json_v1
     stub_request(:get, %r{/persistentvolumes})
-      .to_return(body: open_test_json_file('persistent_volume.json'),
+      .to_return(body: open_test_file('persistent_volume.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'

--- a/test/test_persistent_volume_claim.rb
+++ b/test/test_persistent_volume_claim.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class TestPersistentVolumeClaim < MiniTest::Test
   def test_get_from_json_v1
     stub_request(:get, %r{/persistentvolumeclaims})
-      .to_return(body: open_test_json_file('persistent_volume_claim.json'),
+      .to_return(body: open_test_file('persistent_volume_claim.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'

--- a/test/test_pod.rb
+++ b/test/test_pod.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class TestPod < MiniTest::Test
   def test_get_from_json_v1
     stub_request(:get, %r{/pods})
-      .to_return(body: open_test_json_file('pod.json'),
+      .to_return(body: open_test_file('pod.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'

--- a/test/test_pod_log.rb
+++ b/test/test_pod_log.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+# Pod log tests
+class TestPodLog < MiniTest::Test
+  def test_get_pod_log
+    stub_request(:get, %r{/namespaces/default/pods/[a-z0-9-]+/log})
+      .to_return(body: open_test_text_file('pod_log.txt'),
+                 status: 200)
+
+    client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
+    retrieved_log = client.get_pod_log('redis-master-pod', 'default')
+
+    assert_equal(open_test_text_file('pod_log.txt').read, retrieved_log)
+
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1/namespaces/default/pods/redis-master-pod/log',
+                     times: 1)
+  end
+
+  def test_get_pod_log_container
+    stub_request(:get, %r{/namespaces/default/pods/[a-z0-9-]+/log})
+      .to_return(body: open_test_text_file('pod_log.txt'),
+                 status: 200)
+
+    client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
+    retrieved_log = client.get_pod_log('redis-master-pod', 'default', container: 'ruby')
+
+    assert_equal(open_test_text_file('pod_log.txt').read, retrieved_log)
+
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1/namespaces/default/pods/redis-master-pod/log?container=ruby',
+                     times: 1)
+  end
+
+  def test_watch_pod_log
+    expected_lines = open_test_text_file('pod_log.txt').read.split("\n")
+
+    stub_request(:get, %r{/namespaces/default/pods/[a-z0-9-]+/log\?.*follow})
+      .to_return(body: open_test_text_file('pod_log.txt'),
+                 headers: { 'Content-Type' => 'text/plain' },
+                 status: 200)
+
+    client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
+
+    client.watch_pod_log('redis-master-pod', 'default').to_enum.with_index do |notice, index|
+      assert_instance_of(String, notice)
+      assert_equal(expected_lines[index], notice)
+    end
+  end
+end

--- a/test/test_replication_controller.rb
+++ b/test/test_replication_controller.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class TestReplicationController < MiniTest::Test
   def test_get_from_json_v1
     stub_request(:get, %r{/replicationcontrollers})
-      .to_return(body: open_test_json_file('replication_controller.json'),
+      .to_return(body: open_test_file('replication_controller.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'

--- a/test/test_resource_quota.rb
+++ b/test/test_resource_quota.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class TestResourceQuota < MiniTest::Test
   def test_get_from_json_v1
     stub_request(:get, %r{/resourcequotas})
-      .to_return(body: open_test_json_file('resource_quota.json'),
+      .to_return(body: open_test_file('resource_quota.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'

--- a/test/test_secret.rb
+++ b/test/test_secret.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 class TestSecret < MiniTest::Test
   def test_get_secret_v1
     stub_request(:get, %r{/secrets})
-      .to_return(body: open_test_json_file('created_secret.json'),
+      .to_return(body: open_test_file('created_secret.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
@@ -35,7 +35,7 @@ class TestSecret < MiniTest::Test
 
   def test_create_secret_v1
     stub_request(:post, %r{/secrets})
-      .to_return(body: open_test_json_file('created_secret.json'),
+      .to_return(body: open_test_file('created_secret.json'),
                  status: 201)
 
     secret = Kubeclient::Secret.new

--- a/test/test_service.rb
+++ b/test/test_service.rb
@@ -24,7 +24,7 @@ class TestService < MiniTest::Test
                  hash[:metadata][:labels][:name]
 
     stub_request(:post, %r{namespaces/staging/services})
-      .to_return(body: open_test_json_file('created_service.json'),
+      .to_return(body: open_test_file('created_service.json'),
                  status: 201)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/'
@@ -37,7 +37,7 @@ class TestService < MiniTest::Test
 
   def test_conversion_from_json_v1
     stub_request(:get, %r{/services})
-      .to_return(body: open_test_json_file('service.json'),
+      .to_return(body: open_test_file('service.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/'
@@ -98,7 +98,7 @@ class TestService < MiniTest::Test
 
   def test_get_service
     stub_request(:get, %r{/namespaces/development/services/redis-slave})
-      .to_return(body: open_test_json_file('service.json'),
+      .to_return(body: open_test_file('service.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/'
@@ -120,7 +120,7 @@ class TestService < MiniTest::Test
 
     stub_request(:put, %r{/services/#{name}})\
       .to_return(
-        body: open_test_json_file('service_update.json'),
+        body: open_test_file('service_update.json'),
         status: 200
       )
 

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -10,8 +10,7 @@ class TestWatch < MiniTest::Test
     ]
 
     stub_request(:get, %r{.*\/watch/pods})
-      .to_return(body: open_test_json_file('watch_stream.json'),
-                 headers: { 'Content-Type' => 'application/json' },
+      .to_return(body: open_test_file('watch_stream.json'),
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -11,6 +11,7 @@ class TestWatch < MiniTest::Test
 
     stub_request(:get, %r{.*\/watch/pods})
       .to_return(body: open_test_json_file('watch_stream.json'),
+                 headers: { 'Content-Type' => 'application/json' },
                  status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'

--- a/test/txt/pod_log.txt
+++ b/test/txt/pod_log.txt
@@ -1,0 +1,6 @@
+Initializing server...
+...loaded configuration
+...updated settings
+...discovered local servers
+...frobinated disks
+Complete!


### PR DESCRIPTION
This allows a user to retrieve (or stream) the logs for a particular pod, via the Kubernetes API.
Resolves #119.
