### PR TITLE
common: add support for the ca cert_store

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ client = Kubeclient::Client.new 'https://localhost:8443/api/' , "v1",
                                 ssl_options: ssl_options
 ```
 
+As an alternative to the `ca_file` it's possible to use the `cert_store`:
+
+```ruby
+cert_store = OpenSSL::X509::Store.new
+cert_store.add_cert(OpenSSL::X509::Certificate.new(ca_cert_data))
+ssl_options = {
+  cert_store: cert_store
+  verify_ssl: OpenSSL::SSL::VERIFY_PEER
+}
+client = Kubeclient::Client.new 'https://localhost:8443/api/' , "v1",
+                                ssl_options: ssl_options
+```
+
 For testing and development purpose you can disable the ssl check with:
 
 ```ruby

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -35,9 +35,10 @@ module Kubeclient
                    version = 'v1',
                    ssl_options: {
                      client_cert: nil,
-                     client_key: nil,
-                     ca_file: nil,
-                     verify_ssl: OpenSSL::SSL::VERIFY_PEER
+                     client_key:  nil,
+                     ca_file:     nil,
+                     cert_store:  nil,
+                     verify_ssl:  OpenSSL::SSL::VERIFY_PEER
                    },
                    auth_options: {
                      username:          nil,

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -16,6 +16,7 @@ module Kubeclient
         client_cert: nil,
         client_key: nil,
         ca_file: nil,
+        cert_store: nil,
         verify_ssl: OpenSSL::SSL::VERIFY_PEER
       },
       auth_options: {
@@ -111,6 +112,7 @@ module Kubeclient
       path ||= @api_endpoint.path
       options = {
         ssl_ca_file: @ssl_options[:ca_file],
+        ssl_cert_store: @ssl_options[:cert_store],
         verify_ssl: @ssl_options[:verify_ssl],
         ssl_client_cert: @ssl_options[:client_cert],
         ssl_client_key: @ssl_options[:client_key],
@@ -295,6 +297,7 @@ module Kubeclient
           use_ssl: true,
           ca_file: @ssl_options[:ca_file],
           cert: @ssl_options[:client_cert],
+          cert_store: @ssl_options[:cert_store],
           key: @ssl_options[:client_key],
           # ruby Net::HTTP uses verify_mode instead of verify_ssl
           # http://ruby-doc.org/stdlib-1.9.3/libdoc/net/http/rdoc/Net/HTTP.html


### PR DESCRIPTION
This patch adds the support for the cert_store as an alternative to the ca_file.
