### PR TITLE
get or watch entities using fieldSelector or labelSelector

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ It is possible to interrupt the watcher from another thread with:
 watcher.finish
 ```
 
+#### Watch events for a particular object
+You can use the `field_selector` option as part of the watch methods.
+
+```ruby
+watcher = client.watch_events(namespace: 'development', field_selector: 'involvedObject.name=redis-master')
+watcher.each do |notice|
+  # process notice date
+end
+```
+
 #### Get a proxy URL
 You can get a complete URL for connecting a kubernetes entity via the proxy.
 

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -79,8 +79,12 @@ module Kubeclient
 
         # watch all entities of a type e.g. watch_nodes, watch_pods, etc.
         define_method("watch_#{entity_name_plural}") \
-        do |resource_version = nil|
-          watch_entities(entity_type, resource_version)
+        do |options = {}|
+          # This method used to take resource_version as a param, so
+          # this conversion is to keep backwards compatibility
+          options = { resource_version: options } unless options.is_a?(Hash)
+
+          watch_entities(entity_type, options)
         end
 
         # get a single entity of a specific type by name
@@ -126,28 +130,41 @@ module Kubeclient
       end
     end
 
-    def watch_entities(entity_type, resource_version = nil)
-      resource = resource_name(entity_type.to_s)
-      uri = @api_endpoint
-            .merge("#{@api_endpoint.path}/#{@api_version}/watch/#{resource}")
+    # Accepts the following string options:
+    #   :namespace - the namespace of the entity.
+    #   :name - the name of the entity to watch.
+    #   :label_selector - a selector to restrict the list of returned objects by their labels.
+    #   :field_selector - a selector to restrict the list of returned objects by their fields.
+    #   :resource_version - shows changes that occur after that particular version of a resource.
+    def watch_entities(entity_type, options = {})
+      ns = build_namespace_prefix(options[:namespace])
 
-      unless resource_version.nil?
-        uri.query = URI.encode_www_form('resourceVersion' => resource_version)
+      path = "watch/#{ns}#{resource_name(entity_type.to_s)}"
+      path += "/#{options[:name]}" if options[:name]
+      uri = @api_endpoint.merge("#{@api_endpoint.path}/#{@api_version}/#{path}")
+
+      params = options.slice(:label_selector, :field_selector, :resource_version)
+      if params.any?
+        uri.query = URI.encode_www_form(params.map { |k, v| [k.to_s.camelize(:lower), v] })
       end
 
       Kubeclient::Common::WatchStream.new(uri, net_http_options(uri))
     end
 
+    # Accepts the following string options:
+    #   :namespace - the namespace of the entity.
+    #   :label_selector - a selector to restrict the list of returned objects by their labels.
+    #   :field_selector - a selector to restrict the list of returned objects by their fields.
     def get_entities(entity_type, klass, options = {})
       params = {}
-      if options[:label_selector]
-        params['params'] = { labelSelector: options[:label_selector] }
+      [:label_selector, :field_selector].each do |p|
+        params[p.to_s.camelize(:lower)] = options[p] if options[p]
       end
 
       ns_prefix = build_namespace_prefix(options[:namespace])
       response = handle_exception do
         rest_client[ns_prefix + resource_name(entity_type)]
-        .get(params.merge(@headers))
+        .get({ 'params' => params }.merge(@headers))
       end
 
       result = JSON.parse(response)

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -172,6 +172,38 @@ class KubeClientTest < MiniTest::Test
                      times: 1)
   end
 
+  def test_entities_with_label_selector
+    selector = 'component=apiserver'
+
+    stub_request(:get, %r{/services})
+      .to_return(body: open_test_file('entity_list.json'),
+                 status: 200)
+
+    client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
+    services = client.get_services(label_selector: selector)
+
+    assert_instance_of(Kubeclient::Common::EntityList, services)
+    assert_requested(:get,
+                     "http://localhost:8080/api/v1/services?labelSelector=#{selector}",
+                     times: 1)
+  end
+
+  def test_entities_with_field_selector
+    selector = 'involvedObject.name=redis-master'
+
+    stub_request(:get, %r{/services})
+      .to_return(body: open_test_file('entity_list.json'),
+                 status: 200)
+
+    client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
+    services = client.get_services(field_selector: selector)
+
+    assert_instance_of(Kubeclient::Common::EntityList, services)
+    assert_requested(:get,
+                     "http://localhost:8080/api/v1/services?fieldSelector=#{selector}",
+                     times: 1)
+  end
+
   def test_empty_list
     stub_request(:get, %r{/pods})
       .to_return(body: open_test_file('empty_pod_list.json'),

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -50,4 +50,55 @@ class TestWatch < MiniTest::Test
       assert_equal(expected_lines[index], line)
     end
   end
+
+  def test_watch_with_resource_version
+    api_host = 'http://localhost:8080/api'
+    version = '1995'
+
+    stub_request(:get, %r{.*\/watch/events})
+      .to_return(body: open_test_file('watch_stream.json'),
+                 status: 200)
+
+    client = Kubeclient::Client.new api_host, 'v1'
+    results = client.watch_events(version).to_enum
+
+    assert_equal(3, results.count)
+    assert_requested(:get,
+                     "#{api_host}/v1/watch/events?resourceVersion=#{version}",
+                     times: 1)
+  end
+
+  def test_watch_with_label_selector
+    api_host = 'http://localhost:8080/api'
+    selector = 'name=redis-master'
+
+    stub_request(:get, %r{.*\/watch/events})
+      .to_return(body: open_test_file('watch_stream.json'),
+                 status: 200)
+
+    client = Kubeclient::Client.new api_host, 'v1'
+    results = client.watch_events(label_selector: selector).to_enum
+
+    assert_equal(3, results.count)
+    assert_requested(:get,
+                     "#{api_host}/v1/watch/events?labelSelector=#{selector}",
+                     times: 1)
+  end
+
+  def test_watch_with_field_selector
+    api_host = 'http://localhost:8080/api'
+    selector = 'involvedObject.kind=Pod'
+
+    stub_request(:get, %r{.*\/watch/events})
+      .to_return(body: open_test_file('watch_stream.json'),
+                 status: 200)
+
+    client = Kubeclient::Client.new api_host, 'v1'
+    results = client.watch_events(field_selector: selector).to_enum
+
+    assert_equal(3, results.count)
+    assert_requested(:get,
+                     "#{api_host}/v1/watch/events?fieldSelector=#{selector}",
+                     times: 1)
+  end
 end


### PR DESCRIPTION
This PR adds options to the `get_*` and `watch_*` methods of Client, so you can specify `:label_selector` and `:field_selector` when calling those.

This PR is built on top of PR #121, so we should merge the other PR first.

Resolves #123.