### PR TITLE
add response to KubeException

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -50,7 +50,7 @@ module Kubeclient
         json_error_msg = {}
       end
       err_message = json_error_msg['message'] || e.message
-      raise KubeException.new(e.http_code, err_message)
+      raise KubeException.new(e.http_code, err_message, e.response)
     end
 
     def handle_uri(uri, path)

--- a/lib/kubeclient/kube_exception.rb
+++ b/lib/kubeclient/kube_exception.rb
@@ -1,10 +1,11 @@
 # Kubernetes HTTP Exceptions
 class KubeException < StandardError
-  attr_reader :error_code, :message
+  attr_reader :error_code, :message, :response
 
-  def initialize(error_code, message)
+  def initialize(error_code, message, response)
     @error_code = error_code
     @message = message
+    @response = response
   end
 
   def to_s

--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -19,7 +19,7 @@ module Kubeclient
 
         @http.request(request) do |response|
           unless response.is_a? Net::HTTPSuccess
-            fail KubeException.new(response.code, response.message)
+            fail KubeException.new(response.code, response.message, response)
           end
           response.read_body do |chunk|
             buffer << chunk


### PR DESCRIPTION
Saves the response as an attribute of `KubeException` when it is raised.