### PR TITLE
fix revert add component statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Dependency Status](https://gemnasium.com/abonas/kubeclient.svg)](https://gemnasium.com/abonas/kubeclient)
 
 A Ruby client for Kubernetes REST api.
-The client supports GET, POST, PUT, DELETE on nodes, pods, secrets, services, replication controllers, namespaces, resource quotas, limit ranges, endpoints, persistent volumes and persistent volume claims.
+The client supports GET, POST, PUT, DELETE on nodes, pods, secrets, services, replication controllers, namespaces, resource quotas, limit ranges, endpoints, persistent volumes, persistent volume claims and component statuses.
 The client currently supports Kubernetes REST api version v1.
 
 ## Installation
@@ -118,7 +118,7 @@ client = Kubeclient::Client.new 'https://localhost:8443/api/' , 'v1',
 ## Examples:
 
 #### Get all instances of a specific entity type
-Such as: `get_pods`, `get_secrets`, `get_services`, `get_nodes`, `get_replication_controllers`, `get_resource_quotas`, `get_limit_ranges`, `get_persistent_volumes`, `get_persistent_volume_claims`
+Such as: `get_pods`, `get_secrets`, `get_services`, `get_nodes`, `get_replication_controllers`, `get_resource_quotas`, `get_limit_ranges`, `get_persistent_volumes`, `get_persistent_volume_claims`, `get_component_statuses`
 
 ```ruby
 pods = client.get_pods
@@ -142,7 +142,7 @@ pods = client.get_pods(label_selector: 'name=redis-master,app=redis')
 ```
 
 #### Get a specific instance of an entity (by name)
-Such as: `get_service "service name"` , `get_pod "pod name"` , `get_replication_controller "rc name"`, `get_secret "secret name"`, `get_resource_quota "resource quota name"`, `get_limit_range "limit range name"` , `get_persistent_volume "persistent volume name"` , `get_persistent_volume_claim "persistent volume claim name"`
+Such as: `get_service "service name"` , `get_pod "pod name"` , `get_replication_controller "rc name"`, `get_secret "secret name"`, `get_resource_quota "resource quota name"`, `get_limit_range "limit range name"` , `get_persistent_volume "persistent volume name"` , `get_persistent_volume_claim "persistent volume claim name"`, `get_component_status "component name"`
 
 The GET request should include the namespace name, except for nodes and namespaces entities.
 
@@ -203,8 +203,7 @@ client.update_service service1
 ```
 
 #### Get all entities of all types : all_entities
-Returns a hash with 12 keys (node, secret, service, pod, replication_controller, namespace, resource_quota, limit_range, endpoint, event, persistent_volume and persistent_volume_claim). Each key points to an EntityList of same type.
-
+Returns a hash with 13 keys (node, secret, service, pod, replication_controller, namespace, resource_quota, limit_range, endpoint, event, persistent_volume, persistent_volume_claim and component_status). Each key points to an EntityList of same type.
 This method is a convenience method instead of calling each entity's get method separately.
 
 ```ruby

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -19,7 +19,7 @@ module Kubeclient
     # and especially since currently the class body is empty
     ENTITY_TYPES = %w(Pod Service ReplicationController Node Event Endpoint
                       Namespace Secret ResourceQuota LimitRange PersistentVolume
-                      PersistentVolumeClaim).map do |et|
+                      PersistentVolumeClaim ComponentStatus).map do |et|
       clazz = Class.new(RecursiveOpenStruct) do
         def initialize(hash = nil, args = {})
           args.merge!(recurse_over_arrays: true)

--- a/test/json/component_status.json
+++ b/test/json/component_status.json
@@ -1,0 +1,17 @@
+{
+  "kind": "ComponentStatus",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "etcd-0",
+    "selfLink": "/api/v1/namespaces/componentstatuses/etcd-0",
+    "creationTimestamp": null
+  },
+  "conditions": [
+    {
+      "type": "Healthy",
+      "status": "True",
+      "message": "{\"health\": \"true\"}",
+      "error": "nil"
+    }
+  ]
+}

--- a/test/json/component_status_list.json
+++ b/test/json/component_status_list.json
@@ -1,0 +1,52 @@
+{
+  "kind": "ComponentStatusList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/componentstatuses"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "controller-manager",
+        "selfLink": "/api/v1/namespaces/componentstatuses/controller-manager",
+        "creationTimestamp": null
+      },
+      "conditions": [
+        {
+          "type": "Healthy",
+          "status": "Unknown",
+          "error": "Get http://127.0.0.1:10252/healthz: dial tcp 127.0.0.1:10252: connection refused"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "name": "scheduler",
+        "selfLink": "/api/v1/namespaces/componentstatuses/scheduler",
+        "creationTimestamp": null
+      },
+      "conditions": [
+        {
+          "type": "Healthy",
+          "status": "Unknown",
+          "error": "Get http://127.0.0.1:10251/healthz: dial tcp 127.0.0.1:10251: connection refused"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "name": "etcd-0",
+        "selfLink": "/api/v1/namespaces/componentstatuses/etcd-0",
+        "creationTimestamp": null
+      },
+      "conditions": [
+        {
+          "type": "Healthy",
+          "status": "True",
+          "message": "{\"health\": \"true\"}",
+          "error": "nil"
+        }
+      ]
+    }
+  ]
+}

--- a/test/test_component_status.rb
+++ b/test/test_component_status.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+# ComponentStatus tests
+class TestComponentStatus < MiniTest::Test
+  def test_get_from_json_v3
+    stub_request(:get, %r{/componentstatuses})
+      .to_return(body: open_test_file('component_status.json'),
+                 status: 200)
+
+    client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
+    component_status = client.get_component_status 'etcd-0', 'default'
+
+    assert_instance_of(Kubeclient::ComponentStatus, component_status)
+    assert_equal('etcd-0', component_status.metadata.name)
+    assert_equal('Healthy', component_status.conditions[0].type)
+    assert_equal('True', component_status.conditions[0].status)
+
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1/namespaces/default/componentstatuses/etcd-0',
+                     times: 1)
+  end
+end

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -230,9 +230,13 @@ class KubeClientTest < MiniTest::Test
       .to_return(body: open_test_file('persistent_volume_claim_list.json'),
                  status: 200)
 
+    stub_request(:get, %r{/componentstatuses})
+      .to_return(body: open_test_file('component_status_list.json'),
+                 status: 200)
+
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     result = client.all_entities
-    assert_equal(12, result.keys.size)
+    assert_equal(13, result.keys.size)
     assert_instance_of(Kubeclient::Common::EntityList, result['node'])
     assert_instance_of(Kubeclient::Common::EntityList, result['service'])
     assert_instance_of(Kubeclient::Common::EntityList,
@@ -251,6 +255,7 @@ class KubeClientTest < MiniTest::Test
     assert_instance_of(Kubeclient::LimitRange, result['limit_range'][0])
     assert_instance_of(Kubeclient::PersistentVolume, result['persistent_volume'][0])
     assert_instance_of(Kubeclient::PersistentVolumeClaim, result['persistent_volume_claim'][0])
+    assert_instance_of(Kubeclient::ComponentStatus, result['component_status'][0])
   end
 
   def test_api_bearer_token_with_params_success


### PR DESCRIPTION
This is a fix for the revert "Add Component statuses" (https://github.com/abonas/kubeclient/pull/137)
re-adding the component status entity

