### PR TITLE
Use the non-blocking IO enabled http.rb instead of net/http in watchers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,5 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/LineLength:
   Max: 100
+Metrics/ParameterLists:
+  Max: 8

--- a/README.md
+++ b/README.md
@@ -122,10 +122,22 @@ for more details). For example:
 ```ruby
 auth_options = {
   bearer_token_file: '/var/run/secrets/kubernetes.io/serviceaccount/token'
-
 }
 client = Kubeclient::Client.new 'https://localhost:8443/api/' , 'v1',
                                 auth_options: auth_options
+```
+
+You can also use kubeclient with non-blocking sockets such as Celluloid::IO, see [here](https://github.com/httprb/http/wiki/Parallel-requests-with-Celluloid%3A%3AIO) 
+for details. For example:
+
+```ruby
+require 'celluloid/io'
+socket_options = {
+  socket_class: Celluloid::IO::TCPSocket,
+  ssl_socket_class: Celluloid::IO::SSLSocket
+}
+client = Kubeclient::Client.new 'https://localhost:8443/api/' , 'v1',
+                                socket_options: socket_options
 ```
 
 ## Examples:

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport'
   spec.add_dependency 'json'
   spec.add_dependency 'recursive-open-struct', '= 1.0.0'
-  spec.add_dependency 'http'
+  spec.add_dependency 'http', '= 0.9.8'
 end

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport'
   spec.add_dependency 'json'
   spec.add_dependency 'recursive-open-struct', '= 1.0.0'
+  spec.add_dependency 'http'
 end

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -45,9 +45,14 @@ module Kubeclient
                      password:          nil,
                      bearer_token:      nil,
                      bearer_token_file: nil
+                   },
+                   socket_options: {
+                     socket_class:     nil,
+                     ssl_socket_class: nil
                    }
                   )
-      initialize_client(uri, '/api', version, ssl_options: ssl_options, auth_options: auth_options)
+      initialize_client(uri, '/api', version, ssl_options: ssl_options, auth_options: auth_options,
+                                              socket_options: socket_options)
     end
 
     def all_entities

--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -1,54 +1,65 @@
 require 'json'
-require 'net/http'
+require 'http'
 module Kubeclient
   module Common
     # HTTP Stream used to watch changes on entities
     class WatchStream
       def initialize(uri, http_options, format: :json)
         @uri = uri
-        @http = nil
-        @http_options = http_options.merge(read_timeout: nil)
+        @http_client = nil
+        @http_options = http_options
         @format = format
       end
 
-      def each
+      def each(&block)
         @finished = false
-        @http = Net::HTTP.start(@uri.host, @uri.port, @http_options)
-
-        buffer = ''
-        request = generate_request
-
-        @http.request(request) do |response|
-          unless response.is_a? Net::HTTPSuccess
-            fail KubeException.new(response.code, response.message, response)
-          end
-          response.read_body do |chunk|
-            buffer << chunk
-            while (line = buffer.slice!(/.+\n/))
-              yield @format == :json ? WatchNotice.new(JSON.parse(line)) : line.chomp
-            end
-          end
+        @http_client = build_client
+        response = @http_client.request(:get, @uri, build_client_options)
+        unless response.code < 300
+          fail KubeException.new(response.code, response.reason, response)
         end
-      rescue Errno::EBADF
+        read_stream(response.body, &block)
+      rescue IOError
         raise unless @finished
-      end
-
-      def generate_request
-        request = Net::HTTP::Get.new(@uri)
-        if @http_options[:basic_auth_user] && @http_options[:basic_auth_password]
-          request.basic_auth @http_options[:basic_auth_user],
-                             @http_options[:basic_auth_password]
-        end
-
-        @http_options.fetch(:headers, {}).each do |header, value|
-          request[header.to_s] = value
-        end
-        request
       end
 
       def finish
         @finished = true
-        @http.finish if !@http.nil? && @http.started?
+        @http_client.close unless @http_client.nil?
+      end
+
+      private
+
+      def build_client
+        if @http_options[:basic_auth_user] && @http_options[:basic_auth_password]
+          HTTP.basic_auth(user: @http_options[:basic_auth_user],
+                          pass: @http_options[:basic_auth_password])
+        else
+          HTTP::Client.new
+        end
+      end
+
+      def build_client_options
+        client_options = { headers: @http_options[:headers] }
+        if @http_options[:ssl]
+          client_options[:ssl] = @http_options[:ssl]
+          client_options[:ssl_socket_class] =
+              @http_options[:ssl_socket_class] if @http_options[:ssl_socket_class]
+        else
+          client_options[:socket_class] =
+              @http_options[:socket_class] if @http_options[:socket_class]
+        end
+        client_options
+      end
+
+      def read_stream(response_body)
+        buffer = ''
+        response_body.each do |chunk|
+          buffer << chunk
+          while (line = buffer.slice!(/.+\n/))
+            yield @format == :json ? WatchNotice.new(JSON.parse(line)) : line.chomp
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
When using kubeclient in an actor based concurrent environment, such as Celuloid, we need a non blocking HTTP library to handle watching Kubernetes events. http.rb can be used with Celuloid::IO sockets, so that Celluloid actors remain responsive when awaiting cluster events.

I've tested with basic and ssl authentication options, both with and without the usage of Celluloid::IO. I've not tested thoroughly using bearer token, I only verified that the headers are set when making a request.

This resolves issue #140 