### PR TITLE
Add in the Deployment resource type even though it's still currently in beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Dependency Status](https://gemnasium.com/abonas/kubeclient.svg)](https://gemnasium.com/abonas/kubeclient)
 
 A Ruby client for Kubernetes REST api.
-The client supports GET, POST, PUT, DELETE on nodes, pods, secrets, services, replication controllers, namespaces, resource quotas, limit ranges, endpoints, persistent volumes, persistent volume claims, component statuses and service accounts.
-The client currently supports Kubernetes REST api version v1.
+The client supports GET, POST, PUT, DELETE on nodes, pods, secrets, services, replication controllers, deployments, namespaces, resource quotas, limit ranges, endpoints, persistent volumes, persistent volume claims, component statuses and service accounts.
+The client currently supports Kubernetes REST api version v1 (and limited selection of extension APIs).
 
 ## Installation
 
@@ -36,6 +36,11 @@ Or without specifying version (it will be set by default to "v1")
 
 ```ruby
 client = Kubeclient::Client.new 'http://localhost:8080/api/'
+```
+
+Or to access the extension api groups
+```ruby
+client = Kubeclient::Client.new 'http://localhost:8080/apis', 'extensions/v1beta1'
 ```
 
 Another option is to initialize the client with URI object:
@@ -131,7 +136,7 @@ client = Kubeclient::Client.new 'https://localhost:8443/api/' , 'v1',
 ## Examples:
 
 #### Get all instances of a specific entity type
-Such as: `get_pods`, `get_secrets`, `get_services`, `get_nodes`, `get_replication_controllers`, `get_resource_quotas`, `get_limit_ranges`, `get_persistent_volumes`, `get_persistent_volume_claims`, `get_component_statuses`, `get_service_accounts`
+Such as: `get_pods`, `get_secrets`, `get_services`, `get_nodes`, `get_replication_controllers`, `get_deployments`, `get_resource_quotas`, `get_limit_ranges`, `get_persistent_volumes`, `get_persistent_volume_claims`, `get_component_statuses`, `get_service_accounts`
 
 ```ruby
 pods = client.get_pods
@@ -155,7 +160,7 @@ pods = client.get_pods(label_selector: 'name=redis-master,app=redis')
 ```
 
 #### Get a specific instance of an entity (by name)
-Such as: `get_service "service name"` , `get_pod "pod name"` , `get_replication_controller "rc name"`, `get_secret "secret name"`, `get_resource_quota "resource quota name"`, `get_limit_range "limit range name"` , `get_persistent_volume "persistent volume name"` , `get_persistent_volume_claim "persistent volume claim name"`, `get_component_status "component name"`, `get_service_account "service account name"`
+Such as: `get_service "service name"` , `get_pod "pod name"` , `get_replication_controller "rc name"`, `get_deployment "deployment name"`, `get_secret "secret name"`, `get_resource_quota "resource quota name"`, `get_limit_range "limit range name"` , `get_persistent_volume "persistent volume name"` , `get_persistent_volume_claim "persistent volume claim name"`, `get_component_status "component name"`, `get_service_account "service account name"`
 
 The GET request should include the namespace name, except for nodes and namespaces entities.
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,41 @@ service.metadata.labels.role = 'slave'
 client.create_service service`
 ```
 
+Below example is for the extension API
+```
+deployment = Kubeclient::Deployment.new(
+  {
+    apiVersion: 'extensions/v1beta1',
+    kind: 'Deployment',
+    metadata: {
+      name: 'testdep',
+      namespace: 'default'
+    },
+    spec: {
+      replicas: 1,
+      template: {
+        metadata: {
+          labels: {
+            app: 'nginx'
+          }
+        },
+        spec: {
+          containers: [
+            {
+              name: 'nginx',
+              image: 'nginx:1.7.9',
+              ports: [ { containerPort: 80} ]
+            }
+          ]
+        }
+      }
+    }
+  })
+
+client = Kubeclient::Client.new('http://localhost:8080/apis', 'extensions/v1beta1')
+client.create_deployment(deployment)
+```
+
 #### Update an entity
 For example: `update_pod`, `update_service`, `update_replication_controller`, `update_secret`, `update_resource_quota`, `update_limit_range`, `update_persistent_volume`, `update_persistent_volume_claim`, `update_service_account`
 

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -17,7 +17,7 @@ module Kubeclient
     # This cancels the need to define the classes
     # manually on every new entity addition,
     # and especially since currently the class body is empty
-    ENTITY_TYPES = %w(Pod Service ReplicationController Node Event Endpoint
+    ENTITY_TYPES = %w(Pod Service ReplicationController Deployment Node Event Endpoint
                       Namespace Secret ResourceQuota LimitRange PersistentVolume
                       PersistentVolumeClaim ComponentStatus ServiceAccount).map do |et|
       clazz = Class.new(RecursiveOpenStruct) do

--- a/test/json/deployment.json
+++ b/test/json/deployment.json
@@ -1,0 +1,61 @@
+{
+  "kind": "Deployment",
+  "apiVersion": "extensions/v1beta1",
+  "metadata": {
+    "name": "nginx-deployment",
+    "namespace": "default",
+    "selfLink": "/apis/extensions/v1beta1/namespaces/default/deployments/nginx-deployment",
+    "uid": "7ec56cb1-9f94-11e5-ab34-42010af00002",
+    "resourceVersion": "119317",
+    "creationTimestamp": "2015-12-10T23:19:43Z",
+    "labels": {
+      "app": "nginx"
+    }
+  },
+  "spec": {
+    "replicas": 3,
+    "selector": {
+      "app": "nginx"
+    },
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "nginx",
+            "image": "nginx:1.7.9",
+            "ports": [
+              {
+                "containerPort": 80,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst"
+      }
+    },
+    "strategy": {
+      "type": "RollingUpdate",
+      "rollingUpdate": {
+        "maxUnavailable": 1,
+        "maxSurge": 1
+      }
+    },
+    "uniqueLabelKey": "deployment.kubernetes.io/podTemplateHash"
+  },
+  "status": {
+    "replicas": 3,
+    "updatedReplicas": 3
+  }
+}

--- a/test/json/deployment_list.json
+++ b/test/json/deployment_list.json
@@ -1,0 +1,141 @@
+{
+  "kind": "DeploymentList",
+  "apiVersion": "extensions/v1beta1",
+  "metadata": {
+    "selfLink": "/apis/extensions/v1beta1/namespaces/default/deployments",
+    "resourceVersion": "134702"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "nginx-deployment",
+        "namespace": "default",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/default/deployments/nginx-deployment",
+        "uid": "7ec56cb1-9f94-11e5-ab34-42010af00002",
+        "resourceVersion": "119317",
+        "creationTimestamp": "2015-12-10T23:19:43Z",
+        "labels": {
+          "app": "nginx"
+        }
+      },
+      "spec": {
+        "replicas": 3,
+        "selector": {
+          "app": "nginx"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "app": "nginx"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "nginx",
+                "image": "nginx:1.7.9",
+                "ports": [
+                  {
+                    "containerPort": 80,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent"
+              }
+            ],
+            "restartPolicy": "Always",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst"
+          }
+        },
+        "strategy": {
+          "type": "RollingUpdate",
+          "rollingUpdate": {
+            "maxUnavailable": 1,
+            "maxSurge": 1
+          }
+        },
+        "uniqueLabelKey": "deployment.kubernetes.io/podTemplateHash"
+      },
+      "status": {
+        "replicas": 3,
+        "updatedReplicas": 3
+      }
+    },
+    {
+      "metadata": {
+        "name": "truth-service",
+        "namespace": "default",
+        "selfLink": "/apis/extensions/v1beta1/namespaces/default/deployments/truth-service",
+        "uid": "6f501c89-9f95-11e5-ab34-42010af00002",
+        "resourceVersion": "119500",
+        "creationTimestamp": "2015-12-10T23:26:27Z",
+        "labels": {
+          "project": "truth",
+          "release_id": "24",
+          "role": "app-server"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "project": "truth",
+          "release_id": "24",
+          "role": "app-server"
+        },
+        "template": {
+          "metadata": {
+            "name": "truth-service-pod",
+            "creationTimestamp": null,
+            "labels": {
+              "project": "truth",
+              "release_id": "24",
+              "role": "app-server"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "truth-service",
+                "image": "kubernetes/truth_service:v5",
+                "ports": [
+                  {
+                    "name": "app-server-port",
+                    "containerPort": 4242,
+                    "protocol": "TCP"
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "20m",
+                    "memory": "100Mi"
+                  }
+                },
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent"
+              }
+            ],
+            "restartPolicy": "Always",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst"
+          }
+        },
+        "strategy": {
+          "type": "RollingUpdate",
+          "rollingUpdate": {
+            "maxUnavailable": 1,
+            "maxSurge": 1
+          }
+        },
+        "uniqueLabelKey": "deployment.kubernetes.io/podTemplateHash"
+      },
+      "status": {
+        "replicas": 1,
+        "updatedReplicas": 1
+      }
+    }
+  ]
+}

--- a/test/test_deployment.rb
+++ b/test/test_deployment.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+# Replication Controller entity tests
+class TestDeployment < MiniTest::Test
+  def test_get_from_json_v1
+    stub_request(:get, %r{/deployment})
+      .to_return(body: open_test_file('deployment.json'),
+                 status: 200)
+
+    Kubeclient::Deployment.new
+    client = Kubeclient::Client.new 'http://localhost:8080/apis', 'extensions/v1beta1'
+    deployment = client.get_deployment 'nginx-deployment', 'default'
+
+    assert_instance_of(Kubeclient::Deployment, deployment)
+    assert_equal('nginx-deployment', deployment.metadata.name)
+    assert_equal('7ec56cb1-9f94-11e5-ab34-42010af00002', deployment.metadata.uid)
+    assert_equal('default', deployment.metadata.namespace)
+    assert_equal(3, deployment.spec.replicas)
+    assert_equal('nginx', deployment.spec.selector.app)
+
+    assert_requested(:get,
+                     'http://localhost:8080/apis/extensions/v1beta1/namespaces/default/deployments/nginx-deployment',
+                     times: 1)
+  end
+end

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -270,9 +270,12 @@ class KubeClientTest < MiniTest::Test
       .to_return(body: open_test_file('service_account_list.json'),
                  status: 200)
 
+    stub_request(:get, %r{/deployments})
+      .to_return(body: open_test_file('deployment_list.json'), status: 200)
+
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     result = client.all_entities
-    assert_equal(14, result.keys.size)
+    assert_equal(15, result.keys.size)
     assert_instance_of(Kubeclient::Common::EntityList, result['node'])
     assert_instance_of(Kubeclient::Common::EntityList, result['service'])
     assert_instance_of(Kubeclient::Common::EntityList,


### PR DESCRIPTION
The Deployment API is a great improvement to the current ReplicationController mechanism of deploying your app. (https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/deployments.md).

This change just adds in the new class and methods to use for interacting with the Deployment API. I put an example of how to use it in the README.

cc @msufa @jonmoter