### PR TITLE
Add content-type header = application/json for create and update actions

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -218,6 +218,7 @@ module Kubeclient
       # https://github.com/GoogleCloudPlatform/kubernetes/issues/6439
       hash[:kind]       = entity_type
       hash[:apiVersion] = @api_version
+      @headers['Content-Type'] = 'application/json'
       response = handle_exception do
         rest_client[ns_prefix + resource_name(entity_type)]
         .post(hash.to_json, @headers)
@@ -229,6 +230,7 @@ module Kubeclient
     def update_entity(entity_type, entity_config)
       name      = entity_config[:metadata][:name]
       ns_prefix = build_namespace_prefix(entity_config[:metadata][:namespace])
+      @headers['Content-Type'] = 'application/json'
       handle_exception do
         rest_client[ns_prefix + resource_name(entity_type) + "/#{name}"]
           .put(entity_config.to_h.to_json, @headers)


### PR DESCRIPTION
Following PR  Split codec from scheme #17922 on k8s server.
https://github.com/kubernetes/kubernetes/pull/17922

Without sending content-type, the requests fail.
cc @simon3z 