### PR TITLE
Add HTTP headers to requests for benefit of the server

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -34,7 +34,7 @@ module Kubeclient
       handle_uri(uri, path)
 
       @api_version = version
-      @headers = {}
+      @headers = {:content_type => :json, :accept => :json}
       @ssl_options = ssl_options
       @auth_options = auth_options
       @socket_options = socket_options


### PR DESCRIPTION
While testing out the client with OpenShift latest (including kubernetes
v1.2.0-origin) I hit an issue where requests where rejected because of
missing headers. This patch resolved it.

I've tested this out with 1.1 as well and it appears not to cause any
issues.