### PR TITLE
adding proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ client = Kubeclient::Client.new 'https://localhost:8443/api/' , 'v1',
                                 socket_options: socket_options
 ```
 
+You can also use kubeclient with an http proxy server such as tinyproxy. It can be entered as a string or a URI object
+For example:
+```ruby
+proxy_uri = URI::HTTP.build(host: "myproxyhost", port: 8443)
+client = Kubeclient::Client.new('https://localhost:8443/api/',
+                                :http_proxy_uri => proxy_uri)
+```
+
 ## Examples:
 
 #### Get all instances of a specific entity type

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -24,9 +24,12 @@ module Kubeclient
       ssl_socket_class: nil
     }.freeze
 
+    DEFAULT_HTTP_PROXY_URI = nil
+
     attr_reader :api_endpoint
     attr_reader :ssl_options
     attr_reader :auth_options
+    attr_reader :http_proxy_uri
     attr_reader :headers
 
     def initialize_client(
@@ -35,7 +38,8 @@ module Kubeclient
       version,
       ssl_options: DEFAULT_SSL_OPTIONS,
       auth_options: DEFAULT_AUTH_OPTIONS,
-      socket_options: DEFAULT_SOCKET_OPTIONS
+      socket_options: DEFAULT_SOCKET_OPTIONS,
+      http_proxy_uri: DEFAULT_HTTP_PROXY_URI
     )
       validate_auth_options(auth_options)
       handle_uri(uri, path)
@@ -45,6 +49,7 @@ module Kubeclient
       @ssl_options = ssl_options
       @auth_options = auth_options
       @socket_options = socket_options
+      @http_proxy_uri = http_proxy_uri.to_s if http_proxy_uri
 
       if auth_options[:bearer_token]
         bearer_token(@auth_options[:bearer_token])
@@ -134,6 +139,7 @@ module Kubeclient
         verify_ssl: @ssl_options[:verify_ssl],
         ssl_client_cert: @ssl_options[:client_cert],
         ssl_client_key: @ssl_options[:client_key],
+        proxy: @http_proxy_uri,
         user: @auth_options[:username],
         password: @auth_options[:password]
       }
@@ -361,7 +367,8 @@ module Kubeclient
       options = {
         basic_auth_user: @auth_options[:username],
         basic_auth_password: @auth_options[:password],
-        headers: @headers
+        headers: @headers,
+        http_proxy_uri: @http_proxy_uri
       }
 
       if uri.scheme == 'https'

--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -47,8 +47,23 @@ module Kubeclient
         end
       end
 
+      def using_proxy
+        proxy = @http_options[:http_proxy_uri]
+        return nil unless proxy
+        p_uri = URI.parse(proxy)
+        {
+          proxy_address: p_uri.hostname,
+          proxy_port: p_uri.port,
+          proxy_username: p_uri.user,
+          proxy_password: p_uri.password
+        }
+      end
+
       def build_client_options
-        client_options = { headers: @http_options[:headers] }
+        client_options = {
+          headers: @http_options[:headers],
+          proxy: using_proxy
+        }
         if @http_options[:ssl]
           client_options[:ssl] = @http_options[:ssl]
           client_options[:ssl_socket_class] =


### PR DESCRIPTION
Adding a new optional argument ```http_proxy_uri``` that will be passed to ```RestClient``` as the proxy option.