### PR TITLE
add support for reading tokens and user/pass from kubeconfig [#173]

### DIFF
--- a/test/config/userauth.kubeconfig
+++ b/test/config/userauth.kubeconfig
@@ -1,0 +1,28 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+    insecure-skip-tls-verify: true
+  name: localhost:8443
+contexts:
+- context:
+    cluster: localhost:8443
+    namespace: default
+    user: system:admin:token
+  name: localhost/system:admin:token
+- context:
+    cluster: localhost:8443
+    namespace: default
+    user: system:admin:userpass
+  name: localhost/system:admin:userpass
+current-context: localhost/system:admin:token
+kind: Config
+preferences: {}
+users:
+- name: system:admin:token
+  user:
+    token: 0123456789ABCDEF0123456789ABCDEF
+- name: system:admin:userpass
+  user:
+    username: admin
+    password: pAssw0rd123

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -24,6 +24,23 @@ class KubeClientConfigTest < MiniTest::Test
     check_context(config.context, ssl: false)
   end
 
+  def test_user_token
+    config = Kubeclient::Config.read(test_config_file('userauth.kubeconfig'))
+    assert_equal(['localhost/system:admin:token', 'localhost/system:admin:userpass'], config.contexts)
+    context = config.context('localhost/system:admin:token')
+    check_context(context, ssl: false)
+    assert_equal('0123456789ABCDEF0123456789ABCDEF', context.auth_options[:bearer_token])
+  end
+
+  def test_user_password
+    config = Kubeclient::Config.read(test_config_file('userauth.kubeconfig'))
+    assert_equal(['localhost/system:admin:token', 'localhost/system:admin:userpass'], config.contexts)
+    context = config.context('localhost/system:admin:userpass')
+    check_context(context, ssl: false)
+    assert_equal('admin', context.auth_options[:username])
+    assert_equal('pAssw0rd123', context.auth_options[:password])
+  end
+
   private
 
   def check_context(context, ssl: true)


### PR DESCRIPTION
Fixes abonas/kubeclient#173

Adds support and tests for reading username/password or auth tokens from kubeconfig.

@simon3z, @abonas, @irwaters