### PR TITLE
Add support for processing templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,16 @@ watcher.each do |line|
 end
 ```
 
+#### Process a template
+Returns a processed template containing a list of objects to create.
+Input parameter - template (hash)
+Besides its metadata, the template should include a list of objects to be processed and a list of parameters
+to be substituted. Note that for a required parameter that does not provide a generated value, you must supply a value.
+
+```ruby
+client.process_template template
+```
+
 ## Upgrading
 
 #### past version 1.2.0

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -405,6 +405,15 @@ module Kubeclient
       end
     end
 
+    def process_template(template)
+      ns_prefix = build_namespace_prefix(template[:metadata][:namespace])
+      response = handle_exception do
+        rest_client[ns_prefix + 'processedtemplates']
+        .post(template.to_h.to_json, { 'Content-Type' => 'application/json' }.merge(@headers))
+      end
+      JSON.parse(response)
+    end
+
     def api_valid?
       result = api
       result.is_a?(Hash) && (result['versions'] || []).any? do |group|

--- a/test/json/processed_template.json
+++ b/test/json/processed_template.json
@@ -1,0 +1,27 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "my-templtae",
+    "namespace": "default",
+    "selfLink": "/oapi/v1/namespaces/default/processedtemplates/my-templtae",
+    "uid": "2240c61c-8f70-11e5-a806-001a4a231290",
+    "resourceVersion": "1399",
+    "creationTimestamp": "2015-11-20T10:19:07Z"
+  },
+  "objects": [
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "name": "test/my-service"
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "NAME_PREFIX",
+      "value": "test/"
+    }
+  ]
+}

--- a/test/test_process_template.rb
+++ b/test/test_process_template.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+# Process Template tests
+class TestProcessTemplate < MiniTest::Test
+  def test_process_template
+    client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
+    template = {}
+    template[:metadata] = {}
+    template[:metadata][:name] = 'my-template'
+    template[:metadata][:namespace] = 'default'
+    template[:kind] = 'Template'
+    template[:apiVersion] = 'v1'
+    service = {}
+    service[:metadata] = {}
+    service[:metadata][:name] = '${NAME_PREFIX}my-service'
+    service[:kind] = 'Service'
+    service[:apiVersion] = 'v1'
+    template[:objects] = [service]
+    param = { name: 'NAME_PREFIX', value: 'test/' }
+    template[:parameters] = [param]
+
+    req_body = "{\"metadata\":{\"name\":\"my-template\",\"namespace\":\"default\"},"\
+    "\"kind\":\"Template\",\"apiVersion\":\"v1\",\"objects\":[{\"metadata\":"\
+    "{\"name\":\"${NAME_PREFIX}my-service\"},\"kind\":\"Service\",\"apiVersion\":\"v1\"}],"\
+    "\"parameters\":[{\"name\":\"NAME_PREFIX\",\"value\":\"test/\"}]}"
+
+    expected_url = 'http://localhost:8080/api/v1/namespaces/default/processedtemplates'
+    stub_request(:post, expected_url)
+      .with(body: req_body, headers: { 'Content-Type' => 'application/json' })
+      .to_return(body: open_test_file('processed_template.json'), status: 200)
+
+    processed_template = client.process_template template
+
+    assert_equal('test/my-service', processed_template['objects'].first['metadata']['name'])
+
+    assert_requested(:post, expected_url, times: 1) do |req|
+      data = JSON.parse(req.body)
+      data['kind'] == 'Template' &&
+        data['apiVersion'] == 'v1' &&
+        data['metadata']['name'] == 'my-template' &&
+        data['metadata']['namespace'] == 'default'
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for processing templates. 
A template allows the user to generate a list of objects with certain labels and parameters. This list can be then used in order to create these objects. So, we would like to support processing the template and return the list of objects to create (as part of the processed template). 
Template is currently an [Openshift entity](https://docs.openshift.com/enterprise/3.2/dev_guide/templates.html), and will be added to k8s [here](https://github.com/kubernetes/kubernetes/pull/25293). 
cc @abonas @simon3z @zeari