### PR TITLE
Support k8s api discovery and group api

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Or without specifying version (it will be set by default to "v1")
 client = Kubeclient::Client.new 'http://localhost:8080/api/'
 ```
 
+For A Group Api:
+
+```ruby
+client = Kubeclient::Client.new('http://localhost:8080/apis/batch', 'v1')
+```
+
 Another option is to initialize the client with URI object:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -148,6 +148,23 @@ client = Kubeclient::Client.new('https://localhost:8443/api/',
                                 :http_proxy_uri => proxy_uri)
 ```
 
+### Discovery
+
+Discovery from the kube-apiserver is done lazily on method calls so it would not change behavior.
+
+It can also  be done explicitly:
+```
+client = Kubeclient::Client.new('http://localhost:8080/api', 'v1')
+client.discover
+```
+
+It is possible to check the status of discovery
+```
+unless client.discovered
+  client.discover
+end
+```
+
 ### Kubeclient::Config
 
 If you've been using `kubectl` and have a `.kube/config` file, you can auto-populate a config object using `Kubeclient::Config`:
@@ -356,6 +373,18 @@ watcher.each do |line|
 end
 ```
 
+## Upgrading
+
+#### past version 1.2.0
+Replace Specific Entity class references:
+```ruby
+Kubeclient::Service
+```
+with the generic
+```ruby
+Kubeclient::Resource.new
+```
+Where ever possible.
 
 ## Contributing
 

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -12,40 +12,20 @@ module Kubeclient
   # Kubernetes Client
   class Client
     include ClientMixin
-    # Dynamically creating classes definitions (class Pod, class Service, etc.),
-    # The classes are extending RecursiveOpenStruct.
-    # This cancels the need to define the classes
-    # manually on every new entity addition,
-    # and especially since currently the class body is empty
-    ENTITY_TYPES = %w(Pod Service ReplicationController Node Event Endpoint
-                      Namespace Secret ResourceQuota LimitRange PersistentVolume
-                      PersistentVolumeClaim ComponentStatus ServiceAccount).map do |et|
-      clazz = Class.new(RecursiveOpenStruct) do
-        def initialize(hash = nil, args = {})
-          args.merge!(recurse_over_arrays: true)
-          super(hash, args)
-        end
-      end
-      [Kubeclient.const_set(et, clazz), et]
-    end
-
-    ClientMixin.define_entity_methods(ENTITY_TYPES)
-
+    # define a multipurpose resource class, available before discovery
+    ClientMixin.resource_class(Kubeclient, 'Resource')
     def initialize(
       uri,
       version = 'v1',
       **options
     )
       initialize_client(
+        Kubeclient,
         uri,
         '/api',
         version,
         options
       )
-    end
-
-    def all_entities
-      retrieve_all_entities(ENTITY_TYPES)
     end
   end
 end

--- a/test/cassettes/kubernetes_guestbook.yml
+++ b/test/cassettes/kubernetes_guestbook.yml
@@ -843,4 +843,37 @@ http_interactions:
       string: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"f41e6b27-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"584","creationTimestamp":"2015-08-09T10:03:59Z","deletionTimestamp":"2015-08-09T10:03:59Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Terminating"}}'
     http_version: 
   recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-recorded_with: VCR 2.9.3
+- request:
+    method: get
+    uri: http://10.35.0.23:8080/api/v1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      Host:
+      - localhost:8080
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 29 Aug 2016 15:51:30 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"kind":"APIResourceList","groupVersion":"v1","resources":[{"name":"bindings","namespaced":true,"kind":"Binding"},{"name":"componentstatuses","namespaced":false,"kind":"ComponentStatus"},{"name":"configmaps","namespaced":true,"kind":"ConfigMap"},{"name":"endpoints","namespaced":true,"kind":"Endpoints"},{"name":"events","namespaced":true,"kind":"Event"},{"name":"limitranges","namespaced":true,"kind":"LimitRange"},{"name":"namespaces","namespaced":false,"kind":"Namespace"},{"name":"namespaces/finalize","namespaced":false,"kind":"Namespace"},{"name":"namespaces/status","namespaced":false,"kind":"Namespace"},{"name":"nodes","namespaced":false,"kind":"Node"},{"name":"nodes/proxy","namespaced":false,"kind":"Node"},{"name":"nodes/status","namespaced":false,"kind":"Node"},{"name":"persistentvolumeclaims","namespaced":true,"kind":"PersistentVolumeClaim"},{"name":"persistentvolumeclaims/status","namespaced":true,"kind":"PersistentVolumeClaim"},{"name":"persistentvolumes","namespaced":false,"kind":"PersistentVolume"},{"name":"persistentvolumes/status","namespaced":false,"kind":"PersistentVolume"},{"name":"pods","namespaced":true,"kind":"Pod"},{"name":"pods/attach","namespaced":true,"kind":"Pod"},{"name":"pods/binding","namespaced":true,"kind":"Binding"},{"name":"pods/exec","namespaced":true,"kind":"Pod"},{"name":"pods/log","namespaced":true,"kind":"Pod"},{"name":"pods/portforward","namespaced":true,"kind":"Pod"},{"name":"pods/proxy","namespaced":true,"kind":"Pod"},{"name":"pods/status","namespaced":true,"kind":"Pod"},{"name":"podtemplates","namespaced":true,"kind":"PodTemplate"},{"name":"replicationcontrollers","namespaced":true,"kind":"ReplicationController"},{"name":"replicationcontrollers/scale","namespaced":true,"kind":"Scale"},{"name":"replicationcontrollers/status","namespaced":true,"kind":"ReplicationController"},{"name":"resourcequotas","namespaced":true,"kind":"ResourceQuota"},{"name":"resourcequotas/status","namespaced":true,"kind":"ResourceQuota"},{"name":"secrets","namespaced":true,"kind":"Secret"},{"name":"serviceaccounts","namespaced":true,"kind":"ServiceAccount"},{"name":"services","namespaced":true,"kind":"Service"},{"name":"services/proxy","namespaced":true,"kind":"Service"},{"name":"services/status","namespaced":true,"kind":"Service"}]}
+
+'
+    http_version: 
+  recorded_at: Mon, 29 Aug 2016 15:51:30 GMT
+recorded_with: VCR 3.0.3

--- a/test/json/bindings_list.json
+++ b/test/json/bindings_list.json
@@ -1,0 +1,10 @@
+{
+  "kind": "Status",
+  "apiVersion": "v1",
+  "metadata": {},
+  "status": "Failure",
+  "message": "the server could not find the requested resource",
+  "reason": "NotFound",
+  "details": {},
+  "code": 404
+}

--- a/test/json/config_map_list.json
+++ b/test/json/config_map_list.json
@@ -1,0 +1,9 @@
+{
+  "kind": "ConfigMapList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/configmaps",
+    "resourceVersion": "665"
+  },
+  "items": []
+}

--- a/test/json/core_api_resource_list.json
+++ b/test/json/core_api_resource_list.json
@@ -1,0 +1,181 @@
+{
+  "kind": "APIResourceList",
+  "groupVersion": "v1",
+  "resources": [
+    {
+      "name": "bindings",
+      "namespaced": true,
+      "kind": "Binding"
+    },
+    {
+      "name": "componentstatuses",
+      "namespaced": false,
+      "kind": "ComponentStatus"
+    },
+    {
+      "name": "configmaps",
+      "namespaced": true,
+      "kind": "ConfigMap"
+    },
+    {
+      "name": "endpoints",
+      "namespaced": true,
+      "kind": "Endpoints"
+    },
+    {
+      "name": "events",
+      "namespaced": true,
+      "kind": "Event"
+    },
+    {
+      "name": "limitranges",
+      "namespaced": true,
+      "kind": "LimitRange"
+    },
+    {
+      "name": "namespaces",
+      "namespaced": false,
+      "kind": "Namespace"
+    },
+    {
+      "name": "namespaces/finalize",
+      "namespaced": false,
+      "kind": "Namespace"
+    },
+    {
+      "name": "namespaces/status",
+      "namespaced": false,
+      "kind": "Namespace"
+    },
+    {
+      "name": "nodes",
+      "namespaced": false,
+      "kind": "Node"
+    },
+    {
+      "name": "nodes/proxy",
+      "namespaced": false,
+      "kind": "Node"
+    },
+    {
+      "name": "nodes/status",
+      "namespaced": false,
+      "kind": "Node"
+    },
+    {
+      "name": "persistentvolumeclaims",
+      "namespaced": true,
+      "kind": "PersistentVolumeClaim"
+    },
+    {
+      "name": "persistentvolumeclaims/status",
+      "namespaced": true,
+      "kind": "PersistentVolumeClaim"
+    },
+    {
+      "name": "persistentvolumes",
+      "namespaced": false,
+      "kind": "PersistentVolume"
+    },
+    {
+      "name": "persistentvolumes/status",
+      "namespaced": false,
+      "kind": "PersistentVolume"
+    },
+    {
+      "name": "pods",
+      "namespaced": true,
+      "kind": "Pod"
+    },
+    {
+      "name": "pods/attach",
+      "namespaced": true,
+      "kind": "Pod"
+    },
+    {
+      "name": "pods/binding",
+      "namespaced": true,
+      "kind": "Binding"
+    },
+    {
+      "name": "pods/exec",
+      "namespaced": true,
+      "kind": "Pod"
+    },
+    {
+      "name": "pods/log",
+      "namespaced": true,
+      "kind": "Pod"
+    },
+    {
+      "name": "pods/portforward",
+      "namespaced": true,
+      "kind": "Pod"
+    },
+    {
+      "name": "pods/proxy",
+      "namespaced": true,
+      "kind": "Pod"
+    },
+    {
+      "name": "pods/status",
+      "namespaced": true,
+      "kind": "Pod"
+    },
+    {
+      "name": "podtemplates",
+      "namespaced": true,
+      "kind": "PodTemplate"
+    },
+    {
+      "name": "replicationcontrollers",
+      "namespaced": true,
+      "kind": "ReplicationController"
+    },
+    {
+      "name": "replicationcontrollers/scale",
+      "namespaced": true,
+      "kind": "Scale"
+    },
+    {
+      "name": "replicationcontrollers/status",
+      "namespaced": true,
+      "kind": "ReplicationController"
+    },
+    {
+      "name": "resourcequotas",
+      "namespaced": true,
+      "kind": "ResourceQuota"
+    },
+    {
+      "name": "resourcequotas/status",
+      "namespaced": true,
+      "kind": "ResourceQuota"
+    },
+    {
+      "name": "secrets",
+      "namespaced": true,
+      "kind": "Secret"
+    },
+    {
+      "name": "serviceaccounts",
+      "namespaced": true,
+      "kind": "ServiceAccount"
+    },
+    {
+      "name": "services",
+      "namespaced": true,
+      "kind": "Service"
+    },
+    {
+      "name": "services/proxy",
+      "namespaced": true,
+      "kind": "Service"
+    },
+    {
+      "name": "services/status",
+      "namespaced": true,
+      "kind": "Service"
+    }
+  ]
+}

--- a/test/json/pod_template_list.json
+++ b/test/json/pod_template_list.json
@@ -1,0 +1,9 @@
+{
+  "kind": "PodTemplateList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/podtemplates",
+    "resourceVersion": "672"
+  },
+  "items": []
+}

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -2,34 +2,6 @@ require 'test_helper'
 
 # Unit tests for the common module
 class CommonTest < MiniTest::Test
-  def test_pluralize_entity
-    %w(
-      Pod Pods
-      Service Services
-      ReplicationController ReplicationControllers
-      Node Nodes
-      Event Events
-      Endpoint Endpoints
-      Namespace Namespaces
-      Secret Secrets
-      ResourceQuota ResourceQuotas
-      LimitRange LimitRanges
-      PersistentVolume PersistentVolumes
-      PersistentVolumeClaim PersistentVolumeClaims
-      ComponentStatus ComponentStatuses
-      ServiceAccount ServiceAccounts
-      Project Projects
-      Route Routes
-      ClusterRoleBinding ClusterRoleBindings
-      Build Builds
-      BuildConfig BuildConfigs
-      Image Images
-      ImageStream ImageStreams
-    ).each_slice(2) do |singular, plural|
-      assert_equal(Kubeclient::ClientMixin.pluralize_entity(singular), plural)
-    end
-  end
-
   def test_underscore_entity
     %w(
       Pod pod

--- a/test/test_component_status.rb
+++ b/test/test_component_status.rb
@@ -6,6 +6,9 @@ class TestComponentStatus < MiniTest::Test
     stub_request(:get, %r{/componentstatuses})
       .to_return(body: open_test_file('component_status.json'),
                  status: 200)
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     component_status = client.get_component_status 'etcd-0', 'default'
@@ -15,6 +18,9 @@ class TestComponentStatus < MiniTest::Test
     assert_equal('Healthy', component_status.conditions[0].type)
     assert_equal('True', component_status.conditions[0].status)
 
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1',
+                     times: 1)
     assert_requested(:get,
                      'http://localhost:8080/api/v1/namespaces/default/componentstatuses/etcd-0',
                      times: 1)

--- a/test/test_endpoint.rb
+++ b/test/test_endpoint.rb
@@ -3,8 +3,12 @@ require 'test_helper'
 # Endpoint entity tests
 class TestEndpoint < MiniTest::Test
   def test_create_endpoint
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
+
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
-    testing_ep = Kubeclient::Endpoint.new
+    testing_ep = Kubeclient::Resource.new
     testing_ep.metadata = {}
     testing_ep.metadata.name = 'myendpoint'
     testing_ep.metadata.namespace = 'default'

--- a/test/test_guestbook_go.rb
+++ b/test/test_guestbook_go.rb
@@ -13,7 +13,7 @@ class CreateGuestbookGo < MiniTest::Test
     VCR.use_cassette('kubernetes_guestbook') do # , record: :new_episodes) do
       client = Kubeclient::Client.new 'http://10.35.0.23:8080/api/', 'v1'
 
-      testing_ns = Kubeclient::Namespace.new
+      testing_ns = Kubeclient::Resource.new
       testing_ns.metadata = {}
       testing_ns.metadata.name = 'kubeclient-ns'
 

--- a/test/test_limit_range.rb
+++ b/test/test_limit_range.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 # LimitRange tests
 class TestLimitRange < MiniTest::Test
   def test_get_from_json_v1
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
+
     stub_request(:get, %r{/limitranges})
       .to_return(body: open_test_file('limit_range.json'),
                  status: 200)

--- a/test/test_missing_methods.rb
+++ b/test/test_missing_methods.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+# Test method_missing, respond_to? and respond_to_missing behaviour
+class TestMissingMethods < MiniTest::Test
+  def test_missing
+    stub_request(:get, %r{/api/v1$}).to_return(
+      body: open_test_file('core_api_resource_list.json'),
+      status: 200
+    )
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+    assert_equal(true, client.respond_to?(:get_pod))
+    assert_equal(true, client.respond_to?(:get_pods))
+    assert_equal(false, client.respond_to?(:get_pie))
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1') # Reset discovery
+    assert_equal(false, client.respond_to?(:get_pie))
+    assert_equal(true, client.respond_to?(:get_pods))
+    assert_equal(true, client.respond_to?(:get_pod))
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1') # Reset discovery
+    assert_instance_of(Method, client.method(:get_pods))
+    assert_raises(NameError) do
+      client.method(:get_pies)
+    end
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1') # Reset discovery
+    assert_raises(NameError) do
+      client.method(:get_pies)
+    end
+    assert_instance_of(Method, client.method(:get_pods))
+
+    stub_request(:get, %r{/api/v1$}).to_return(
+      body: '',
+      status: 404
+    ) # If discovery fails we expect the below raise an exception
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+    assert_raises(KubeException) do
+      client.method(:get_pods)
+    end
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+    assert_raises(KubeException) do
+      client.respond_to?(:get_pods)
+    end
+  end
+end

--- a/test/test_namespace.rb
+++ b/test/test_namespace.rb
@@ -3,6 +3,9 @@ require 'test_helper'
 # Namespace entity tests
 class TestNamespace < MiniTest::Test
   def test_get_namespace_v1
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:get, %r{/namespaces})
       .to_return(body: open_test_file('namespace.json'),
                  status: 200)
@@ -22,10 +25,13 @@ class TestNamespace < MiniTest::Test
   end
 
   def test_delete_namespace_v1
-    our_namespace = Kubeclient::Namespace.new
+    our_namespace = Kubeclient::Resource.new
     our_namespace.metadata = {}
     our_namespace.metadata.name = 'staging'
 
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:delete, %r{/namespaces})
       .to_return(status: 200)
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
@@ -37,11 +43,14 @@ class TestNamespace < MiniTest::Test
   end
 
   def test_create_namespace
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:post, %r{/namespaces})
       .to_return(body: open_test_file('created_namespace.json'),
                  status: 201)
 
-    namespace = Kubeclient::Namespace.new
+    namespace = Kubeclient::Resource.new
     namespace.metadata = {}
     namespace.metadata.name = 'development'
 

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -6,6 +6,9 @@ class TestNode < MiniTest::Test
     stub_request(:get, %r{/nodes})
       .to_return(body: open_test_file('node.json'),
                  status: 200)
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     node = client.get_node('127.0.0.1')
@@ -18,6 +21,9 @@ class TestNode < MiniTest::Test
     assert_equal('v1', node.apiVersion)
     assert_equal('2015-03-19T15:08:20+02:00', node.metadata.creationTimestamp)
 
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1',
+                     times: 1)
     assert_requested(:get,
                      'http://localhost:8080/api/v1/nodes/127.0.0.1',
                      times: 1)

--- a/test/test_persistent_volume.rb
+++ b/test/test_persistent_volume.rb
@@ -6,6 +6,9 @@ class TestPersistentVolume < MiniTest::Test
     stub_request(:get, %r{/persistentvolumes})
       .to_return(body: open_test_file('persistent_volume.json'),
                  status: 200)
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     volume = client.get_persistent_volume 'pv0001'
@@ -15,6 +18,9 @@ class TestPersistentVolume < MiniTest::Test
     assert_equal('10Gi', volume.spec.capacity.storage)
     assert_equal('/tmp/data01', volume.spec.hostPath.path)
 
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1',
+                     times: 1)
     assert_requested(:get,
                      'http://localhost:8080/api/v1/persistentvolumes/pv0001',
                      times: 1)

--- a/test/test_persistent_volume_claim.rb
+++ b/test/test_persistent_volume_claim.rb
@@ -6,6 +6,9 @@ class TestPersistentVolumeClaim < MiniTest::Test
     stub_request(:get, %r{/persistentvolumeclaims})
       .to_return(body: open_test_file('persistent_volume_claim.json'),
                  status: 200)
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     claim = client.get_persistent_volume_claim 'myclaim-1', 'default'
@@ -15,6 +18,9 @@ class TestPersistentVolumeClaim < MiniTest::Test
     assert_equal('3Gi', claim.spec.resources.requests.storage)
     assert_equal('pv0001', claim.spec.volumeName)
 
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1',
+                     times: 1)
     assert_requested(:get,
                      'http://localhost:8080/api/v1/namespaces/default/persistentvolumeclaims/myclaim-1',
                      times: 1)

--- a/test/test_pod.rb
+++ b/test/test_pod.rb
@@ -6,6 +6,9 @@ class TestPod < MiniTest::Test
     stub_request(:get, %r{/pods})
       .to_return(body: open_test_file('pod.json'),
                  status: 200)
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     pod = client.get_pod 'redis-master-pod', 'default'
@@ -14,6 +17,9 @@ class TestPod < MiniTest::Test
     assert_equal('redis-master3', pod.metadata.name)
     assert_equal('dockerfile/redis', pod.spec.containers[0]['image'])
 
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1',
+                     times: 1)
     assert_requested(:get,
                      'http://localhost:8080/api/v1/namespaces/default/pods/redis-master-pod',
                      times: 1)

--- a/test/test_replication_controller.rb
+++ b/test/test_replication_controller.rb
@@ -3,6 +3,9 @@ require 'test_helper'
 # Replication Controller entity tests
 class TestReplicationController < MiniTest::Test
   def test_get_from_json_v1
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:get, %r{/replicationcontrollers})
       .to_return(body: open_test_file('replication_controller.json'),
                  status: 200)

--- a/test/test_resource_quota.rb
+++ b/test/test_resource_quota.rb
@@ -3,6 +3,9 @@ require 'test_helper'
 # ResourceQuota tests
 class TestResourceQuota < MiniTest::Test
   def test_get_from_json_v1
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:get, %r{/resourcequotas})
       .to_return(body: open_test_file('resource_quota.json'),
                  status: 200)

--- a/test/test_secret.rb
+++ b/test/test_secret.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 # Namespace entity tests
 class TestSecret < MiniTest::Test
   def test_get_secret_v1
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
+
     stub_request(:get, %r{/secrets})
       .to_return(body: open_test_file('created_secret.json'),
                  status: 200)
@@ -22,6 +26,10 @@ class TestSecret < MiniTest::Test
   end
 
   def test_delete_secret_v1
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
+
     stub_request(:delete, %r{/secrets})
       .to_return(status: 200)
 
@@ -34,11 +42,15 @@ class TestSecret < MiniTest::Test
   end
 
   def test_create_secret_v1
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
+
     stub_request(:post, %r{/secrets})
       .to_return(body: open_test_file('created_secret.json'),
                  status: 201)
 
-    secret = Kubeclient::Secret.new
+    secret = Kubeclient::Resource.new
     secret.metadata = {}
     secret.metadata.name = 'test-secret'
     secret.metadata.namespace = 'dev'

--- a/test/test_service.rb
+++ b/test/test_service.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 # Service entity tests
 class TestService < MiniTest::Test
   def test_construct_our_own_service
-    our_service = Kubeclient::Service.new
+    our_service = Kubeclient::Resource.new
     our_service.metadata = {}
     our_service.metadata.name = 'guestbook'
     our_service.metadata.namespace = 'staging'
@@ -24,6 +24,10 @@ class TestService < MiniTest::Test
                  hash[:metadata][:labels][:name]
 
     expected_url = 'http://localhost:8080/api/v1/namespaces/staging/services'
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
+
     stub_request(:post, expected_url)
       .to_return(body: open_test_file('created_service.json'), status: 201)
 
@@ -47,7 +51,7 @@ class TestService < MiniTest::Test
   end
 
   def test_construct_service_from_symbol_keys
-    service = Kubeclient::Service.new
+    service = Kubeclient::Resource.new
     service.metadata = {
       labels: { tier: 'frontend' },
       name: 'test-service',
@@ -62,6 +66,9 @@ class TestService < MiniTest::Test
     }
 
     expected_url = 'http://localhost:8080/api/v1/namespaces/staging/services'
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:post, expected_url)
       .to_return(body: open_test_file('created_service.json'), status: 201)
 
@@ -79,7 +86,7 @@ class TestService < MiniTest::Test
   end
 
   def test_construct_service_from_string_keys
-    service = Kubeclient::Service.new
+    service = Kubeclient::Resource.new
     service.metadata = {
       'labels' => { 'tier' => 'frontend' },
       'name' => 'test-service',
@@ -93,6 +100,9 @@ class TestService < MiniTest::Test
       }]
     }
 
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     expected_url = 'http://localhost:8080/api/v1/namespaces/staging/services'
     stub_request(:post, %r{namespaces/staging/services})
       .to_return(body: open_test_file('created_service.json'), status: 201)
@@ -111,6 +121,9 @@ class TestService < MiniTest::Test
   end
 
   def test_conversion_from_json_v1
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:get, %r{/services})
       .to_return(body: open_test_file('service.json'),
                  status: 200)
@@ -139,13 +152,16 @@ class TestService < MiniTest::Test
   end
 
   def test_delete_service
-    our_service = Kubeclient::Service.new
+    our_service = Kubeclient::Resource.new
     our_service.name = 'redis-service'
     # TODO, new ports assignment to be added
     our_service.labels = {}
     our_service.labels.component = 'apiserver'
     our_service.labels.provider = 'kubernetes'
 
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:delete, %r{/namespaces/default/services})
       .to_return(status: 200)
 
@@ -158,6 +174,9 @@ class TestService < MiniTest::Test
   end
 
   def test_get_service_no_ns
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     # when not specifying namespace for entities which
     # are not node or namespace, the request will fail
     stub_request(:get, %r{/services/redis-slave})
@@ -172,6 +191,9 @@ class TestService < MiniTest::Test
   end
 
   def test_get_service
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:get, %r{/namespaces/development/services/redis-slave})
       .to_return(body: open_test_file('service.json'),
                  status: 200)
@@ -186,13 +208,16 @@ class TestService < MiniTest::Test
   end
 
   def test_update_service
-    service = Kubeclient::Service.new
+    service = Kubeclient::Resource.new
     name = 'my_service'
 
     service.metadata = {}
     service.metadata.name      = name
     service.metadata.namespace = 'development'
 
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     expected_url = "http://localhost:8080/api/v1/namespaces/development/services/#{name}"
     stub_request(:put, expected_url)
       .to_return(body: open_test_file('service_update.json'), status: 201)
@@ -208,7 +233,7 @@ class TestService < MiniTest::Test
   end
 
   def test_update_service_with_string_keys
-    service = Kubeclient::Service.new
+    service = Kubeclient::Resource.new
     name = 'my_service'
 
     service.metadata = {
@@ -216,6 +241,9 @@ class TestService < MiniTest::Test
       'namespace' => 'development'
     }
 
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     expected_url = "http://localhost:8080/api/v1/namespaces/development/services/#{name}"
     stub_request(:put, expected_url)
       .to_return(body: open_test_file('service_update.json'), status: 201)
@@ -231,13 +259,16 @@ class TestService < MiniTest::Test
   end
 
   def test_patch_service
-    service = Kubeclient::Service.new
+    service = Kubeclient::Resource.new
     name = 'my_service'
 
     service.metadata = {}
     service.metadata.name      = name
     service.metadata.namespace = 'development'
 
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     expected_url = "http://localhost:8080/api/v1/namespaces/development/services/#{name}"
     stub_request(:patch, expected_url)
       .to_return(body: open_test_file('service_patch.json'), status: 200)

--- a/test/test_service_account.rb
+++ b/test/test_service_account.rb
@@ -6,6 +6,9 @@ class TestServiceAccount < MiniTest::Test
     stub_request(:get, %r{/serviceaccounts})
       .to_return(body: open_test_file('service_account.json'),
                  status: 200)
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     account = client.get_service_account 'default'
@@ -17,6 +20,9 @@ class TestServiceAccount < MiniTest::Test
 
     assert_requested(:get,
                      'http://localhost:8080/api/v1/serviceaccounts/default',
+                     times: 1)
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1',
                      times: 1)
   end
 end

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -9,6 +9,10 @@ class TestWatch < MiniTest::Test
       { 'type' => 'DELETED', 'resourceVersion' => '1398' }
     ]
 
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
+
     stub_request(:get, %r{.*\/watch/pods})
       .to_return(body: open_test_file('watch_stream.json'),
                  status: 200)
@@ -26,6 +30,9 @@ class TestWatch < MiniTest::Test
   end
 
   def test_watch_pod_failure
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:get, %r{.*\/watch/pods}).to_return(status: 404)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
@@ -54,7 +61,9 @@ class TestWatch < MiniTest::Test
   def test_watch_with_resource_version
     api_host = 'http://localhost:8080/api'
     version = '1995'
-
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:get, %r{.*\/watch/events})
       .to_return(body: open_test_file('watch_stream.json'),
                  status: 200)
@@ -72,6 +81,9 @@ class TestWatch < MiniTest::Test
     api_host = 'http://localhost:8080/api'
     selector = 'name=redis-master'
 
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:get, %r{.*\/watch/events})
       .to_return(body: open_test_file('watch_stream.json'),
                  status: 200)
@@ -89,6 +101,9 @@ class TestWatch < MiniTest::Test
     api_host = 'http://localhost:8080/api'
     selector = 'involvedObject.kind=Pod'
 
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'),
+                 status: 200)
     stub_request(:get, %r{.*\/watch/events})
       .to_return(body: open_test_file('watch_stream.json'),
                  status: 200)


### PR DESCRIPTION
#### Creating the client
Currently we support arguments for kubernetes api path and version and guess '/api' and 'v1' if not provided.
Both of these are valid today and create a client for the same endpoint:
```
client = Kubeclient::Client.new('http://localhost:8080/api', 'v1')
client = Kubeclient::Client.new('http://localhost:8080')
```

It is now possible to create a client for a group api:
```
client = Kubeclient::Client.new('http://localhost:8080/apis/batch', 'v1')
```
#### Discovery
Discovery is done lazily on method calls so it should not change behavior. 

It can also  be done explicitly:
```
client = Kubeclient::Client.new('http://localhost:8080/api', 'v1')
client.discover
```

It is possible to check the status of discovery
```
unless client.discovered
  client.discover
end
```

### Non Backward compatible changes
#### Class definitions

It is no longer possible to support the following code:
```
require 'kubeclient'

service = Kubeclient::Service.new
```

Since classes are no longer statically defined they will not be available at require time.

One solution for this added here is to use the generic `Resource`:
```
service = Kubeclient::Resource.new

```
used to fix some of the tests. I suggest to use this everywhere (including the Readme) since specific entity classes hold no logic and the following will work:

```
client.create_pod(Kubeclient::Service.new)
``` 

Class definitions after the discovery would work but I do not suggest to relay on that .

### Resources in need of special attention
Here is an example for how a normal resource looks in discovery:
```
    {
      "name": "componentstatuses",
      "namespaced": false,
      "kind": "ComponentStatus"
    },
```

####  Endpoints
```
    {
      "name": "endpoints",
      "namespaced": true,
      "kind": "Endpoints" # kind is plural!
    },
```
See https://github.com/kubernetes/kubernetes/issues/8115 complete backward compatibility is currently maintained with specific code in discovery and Endpoint creation. 

As a side note, it would be possible to drop the special handling (and change interface) if we follow https://github.com/kubernetes/kubernetes/issues/18622 and oc client and have kubeclient react the same to plural and singular methods. to distinguish between get one and get all we would have to look at the parameters but that seems completely doable.

#### Resources not supporting GET
```
    {
      "name": "bindings",
      "namespaced": true,
      "kind": "Binding"
    },
```
Bindings is an example for a resource that does not support get, all_entities ignores exceptions so that it keeps working. I don't think there is a way to learn that it does not support get in discovery except for queering it. 

#### Non verbs
Some resources do not fall under the logic kubeclient currently support and should be ignored by discovery. These include:
From k8s /apis/extensions/v1beta1

```
    {
      "name": "replicationcontrollers",
      "namespaced": true,
      "kind": "ReplicationControllerDummy"
    },
```

 See also: https://github.com/kubernetes/kubernetes/issues/22413

OpenShift:
 
```
    {
      "name": "generatedeploymentconfigs",
      "namespaced": true,
      "kind": "DeploymentConfig"
    },
...
    {
      "name": "processedtemplates",
      "namespaced": true,
      "kind": "Template"
    },
```

As reference, all the resource currently returned in discovery from k8s core and groups as well as OpenShift can be found [here](https://gist.github.com/moolitayer/c5d831936bef690aa641089e3a55743a)

### openshift_client
Since OpenShift support discovery in the same way, It is possible to create a client for OpenShift using Kubeclient:
```
Kubeclient::Client.new('http://localhost:8443/oapi')
```

So it could be possible in the future to drop openshift_client in favor of kubeclient if that is desirable.

This also brings the possibility of having a forwarding client - just like how oc can work on k8s entities. That would be helpful for some current efforts like generation from templates but is outside the scope of this pr.

### Out of the scope of this pr
- Discovery of nested resources (```namespaces/finalize```)
- Discovery of first level resources (```/healthz```)

This continues the work done in #184 to drop activesupport removing the last method that had lingual logic: pluralize_entities in favor of discovery..

Fixes #144  
Fixes #189