### PR TITLE
Fix class extraction

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -154,17 +154,19 @@ module Kubeclient
     public
 
     def self.resource_class(class_owner, entity_type)
-      class_owner.const_get(entity_type, false)
-    rescue NameError
-      class_owner.const_set(
-        entity_type,
-        Class.new(RecursiveOpenStruct) do
-          def initialize(hash = nil, args = {})
-            args[:recurse_over_arrays] = true
-            super(hash, args)
+      if class_owner.const_defined?(entity_type, false)
+        class_owner.const_get(entity_type, false)
+      else
+        class_owner.const_set(
+          entity_type,
+          Class.new(RecursiveOpenStruct) do
+            def initialize(hash = nil, args = {})
+              args[:recurse_over_arrays] = true
+              super(hash, args)
+            end
           end
-        end
-      )
+        )
+      end
     end
 
     def define_entity_methods


### PR DESCRIPTION
Reproduction:
- Install the gem into ManageIQ
- Execute
```
bundle exec rspec ./spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
```
(I wonder why that does not run as part of travis tests?)

We get an error [1]. The cause is the code before this change 
```
class_owner.const_get(entity_type, false)
```
Returns the class 'Service' from ManageIQ instead of only looking for only Kubeclient::Service

[1]   1) ManageIQ::Providers::Openshift::ContainerManager::Refresher will perform a full refresh on openshift
     Failure/Error: super
     
     ActiveModel::UnknownAttributeError:
       unknown attribute 'metadata' for Service.
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/activemodel-5.0.0.1/lib/active_model/attribute_assignment.rb:48:in `_assign_attribute'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/activerecord-5.0.0.1/lib/active_record/attribute_assignment.rb:34:in `block in assign_nested_parameter_attributes'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/activerecord-5.0.0.1/lib/active_record/attribute_assignment.rb:34:in `each'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/activerecord-5.0.0.1/lib/active_record/attribute_assignment.rb:34:in `assign_nested_parameter_attributes'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/activerecord-5.0.0.1/lib/active_record/attribute_assignment.rb:28:in `_assign_attributes'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/activemodel-5.0.0.1/lib/active_model/attribute_assignment.rb:33:in `assign_attributes'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/activerecord-5.0.0.1/lib/active_record/core.rb:319:in `initialize'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/activerecord-5.0.0.1/lib/active_record/inheritance.rb:65:in `new'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/activerecord-5.0.0.1/lib/active_record/inheritance.rb:65:in `new'
     # ./app/models/mixins/new_with_type_sti_mixin.rb:16:in `new'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/kubeclient-2.0.0/lib/kubeclient/common.rb:348:in `new_entity'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/kubeclient-2.0.0/lib/kubeclient/common.rb:278:in `block in get_entities'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/kubeclient-2.0.0/lib/kubeclient/common.rb:278:in `map'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/kubeclient-2.0.0/lib/kubeclient/common.rb:278:in `get_entities'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/kubeclient-2.0.0/lib/kubeclient/common.rb:175:in `block (2 levels) in define_entity_methods'
     # ./app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb:16:in `block in fetch_entities'
     # ./app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb:14:in `each'
     # ./app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb:14:in `each_with_object'
     # ./app/models/manageiq/providers/kubernetes/container_manager/refresher_mixin.rb:14:in `fetch_entities'
     # ./app/models/manageiq/providers/openshift/container_manager/refresher.rb:16:in `block in parse_legacy_inventory'
     # ./app/models/ext_management_system.rb:360:in `with_provider_connection'
     # ./app/models/manageiq/providers/openshift/container_manager/refresher.rb:15:in `parse_legacy_inventory'
     # ./app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:122:in `block in parse_targeted_inventory'
     # ./gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
     # ./gems/pending/util/extensions/miq-benchmark.rb:30:in `realtime_block'
     # ./app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:122:in `parse_targeted_inventory'
     # ./app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:87:in `block in refresh_targets_for_ems'
     # ./gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
     # ./gems/pending/util/extensions/miq-benchmark.rb:30:in `realtime_block'
     # ./app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:86:in `refresh_targets_for_ems'
     # ./app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:24:in `block (2 levels) in refresh'
     # ./gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
     # ./gems/pending/util/extensions/miq-benchmark.rb:30:in `realtime_block'
     # ./app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:24:in `block in refresh'
     # ./app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:14:in `each'
     # ./app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:14:in `refresh'
     # ./app/models/manageiq/providers/base_manager/refresher.rb:10:in `refresh'
     # ./app/models/ems_refresh.rb:77:in `block in refresh'
     # ./app/models/ems_refresh.rb:76:in `each'
     # ./app/models/ems_refresh.rb:76:in `refresh'
     # ./spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb:21:in `block (4 levels) in <top (required)>'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/vcr-3.0.3/lib/vcr/util/variable_args_block_caller.rb:9:in `call_block'
     # /home/mtayer/.rvm/gems/ruby-2.3.0/gems/vcr-3.0.3/lib/vcr.rb:189:in `use_cassette'
     # ./spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb:12:in `times'
     # ./spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb:12:in `block (2 levels) in <top (required)>'
