### PR TITLE
Fix undefined method `rindex'

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -111,7 +111,7 @@ module Kubeclient
       @entities = {}
       result = JSON.parse(handle_exception { rest_client.get(@headers) })
       result['resources'].each do |resource|
-        next if resource['name'].include?('/')
+        next if resource['name'].include?('/') || resource['kind'].nil?
         entity = ClientMixin.parse_definition(resource['kind'], resource['name'])
         @entities[entity.method_names[0]] = entity if entity
       end


### PR DESCRIPTION
A possible fix for: BZ https://bugzilla.redhat.com/show_bug.cgi?id=1387614

The fix handles a 'nil' `kind`. However, we would expect that each resource would have a well defined `kind`, so I'm not sure if this is the right approach here, asked for more information in the BZ. 

@simon3z @moolitayer @zeari @cben