### PR TITLE
Enable "gcp" authentication structure for bearer token in .kube/config

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -104,6 +104,9 @@ module Kubeclient
         {}
       end
       err_message = json_error_msg['message'] || e.message
+      if e.http_code == 401 && @auth_options.key?(:bearer_token_expiry) && @auth_options[:bearer_token_expiry] < Time.now
+        err_message += '. Your token has expired. If you are using `kubectl`, running any command should renew your token.'
+      end
       raise KubeException.new(e.http_code, err_message, e.response)
     end
 

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -104,7 +104,7 @@ module Kubeclient
         {}
       end
 
-      err_message = expired_token_message(
+      err_message = check_token_expiration(
         e.http_code,
         json_error_msg['message'] || e.message
       )
@@ -483,7 +483,7 @@ module Kubeclient
       options.merge(@socket_options)
     end
 
-    def expired_token_message(http_code, message)
+    def check_token_expiration(http_code, message)
       if http_code == 401 &&
          @auth_options.key?(:bearer_token_expiry) &&
          @auth_options[:bearer_token_expiry] < Time.now

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -103,10 +103,12 @@ module Kubeclient
       rescue JSON::ParserError
         {}
       end
-      err_message = json_error_msg['message'] || e.message
-      if e.http_code == 401 && @auth_options.key?(:bearer_token_expiry) && @auth_options[:bearer_token_expiry] < Time.now
-        err_message += '. Your token has expired. If you are using `kubectl`, running any command should renew your token.'
-      end
+
+      err_message = expired_token_message(
+        e.http_code,
+        json_error_msg['message'] || e.message
+      )
+
       raise KubeException.new(e.http_code, err_message, e.response)
     end
 
@@ -479,6 +481,17 @@ module Kubeclient
       end
 
       options.merge(@socket_options)
+    end
+
+    def expired_token_message(http_code, message)
+      if http_code == 401 &&
+         @auth_options.key?(:bearer_token_expiry) &&
+         @auth_options[:bearer_token_expiry] < Time.now
+        return message + '. Your token has expired. If you are using `kubectl`, running any '\
+          'command should renew your token.'
+      end
+
+      message
     end
   end
 end

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -115,7 +115,9 @@ module Kubeclient
       options = {}
       if user.key?('token')
         options[:bearer_token] = user['token']
-      elsif user.key?('auth-provider') && user['auth-provider'].key?('config') && user['auth-provider']['config'].key?('access-token')
+      elsif user.key?('auth-provider') &&
+            user['auth-provider'].key?('config') &&
+            user['auth-provider']['config'].key?('access-token')
         options[:bearer_token] = user['auth-provider']['config']['access-token']
         options[:bearer_token_expiry] = user['auth-provider']['config']['expiry']
       else

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -115,6 +115,9 @@ module Kubeclient
       options = {}
       if user.key?('token')
         options[:bearer_token] = user['token']
+      elsif user.key?('auth-provider') && user['auth-provider'].key?('config') && user['auth-provider']['config'].key?('access-token')
+        options[:bearer_token] = user['auth-provider']['config']['access-token']
+        options[:bearer_token_expiry] = user['auth-provider']['config']['expiry']
       else
         %w(username password).each do |attr|
           options[attr.to_sym] = user[attr] if user.key?(attr)

--- a/test/config/userauth.kubeconfig
+++ b/test/config/userauth.kubeconfig
@@ -15,6 +15,11 @@ contexts:
     namespace: default
     user: system:admin:userpass
   name: localhost/system:admin:userpass
+- context:
+    cluster: localhost:8443
+    namespace: default
+    user: system:admin:gcptoken
+  name: localhost/system:admin:gcptoken
 current-context: localhost/system:admin:token
 kind: Config
 preferences: {}
@@ -26,3 +31,10 @@ users:
   user:
     username: admin
     password: pAssw0rd123
+- name: system:admin:gcptoken
+  user:
+    auth-provider:
+      config:
+        access-token: ya29.C0987654321QWERTYUIOPW
+        expiry: 2016-11-11T13:11:05.0-00:00
+      name: gcp

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -26,8 +26,14 @@ class KubeClientConfigTest < MiniTest::Test
 
   def test_user_token
     config = Kubeclient::Config.read(test_config_file('userauth.kubeconfig'))
-    assert_equal(['localhost/system:admin:token', 'localhost/system:admin:userpass', 'localhost/system:admin:gcptoken'],
-                 config.contexts)
+    assert_equal(
+      [
+        'localhost/system:admin:token',
+        'localhost/system:admin:userpass',
+        'localhost/system:admin:gcptoken'
+      ],
+      config.contexts
+    )
     context = config.context('localhost/system:admin:token')
     check_context(context, ssl: false)
     assert_equal('0123456789ABCDEF0123456789ABCDEF', context.auth_options[:bearer_token])
@@ -35,8 +41,14 @@ class KubeClientConfigTest < MiniTest::Test
 
   def test_user_password
     config = Kubeclient::Config.read(test_config_file('userauth.kubeconfig'))
-    assert_equal(['localhost/system:admin:token', 'localhost/system:admin:userpass', 'localhost/system:admin:gcptoken'],
-                 config.contexts)
+    assert_equal(
+      [
+        'localhost/system:admin:token',
+        'localhost/system:admin:userpass',
+        'localhost/system:admin:gcptoken'
+      ],
+      config.contexts
+    )
     context = config.context('localhost/system:admin:userpass')
     check_context(context, ssl: false)
     assert_equal('admin', context.auth_options[:username])
@@ -45,12 +57,21 @@ class KubeClientConfigTest < MiniTest::Test
 
   def test_gcp_token
     config = Kubeclient::Config.read(test_config_file('userauth.kubeconfig'))
-    assert_equal(['localhost/system:admin:token', 'localhost/system:admin:userpass', 'localhost/system:admin:gcptoken'],
-                 config.contexts)
+    assert_equal(
+      [
+        'localhost/system:admin:token',
+        'localhost/system:admin:userpass',
+        'localhost/system:admin:gcptoken'
+      ],
+      config.contexts
+    )
     context = config.context('localhost/system:admin:gcptoken')
     check_context(context, ssl: false)
     assert_equal('ya29.C0987654321QWERTYUIOPW', context.auth_options[:bearer_token])
-    assert_equal(Time.new(2016, 11, 11, 13, 11, 5.0, '+00:00'), context.auth_options[:bearer_token_expiry])
+    assert_equal(
+      Time.new(2016, 11, 11, 13, 11, 5.0, '+00:00'),
+      context.auth_options[:bearer_token_expiry]
+    )
   end
 
   private

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -26,7 +26,7 @@ class KubeClientConfigTest < MiniTest::Test
 
   def test_user_token
     config = Kubeclient::Config.read(test_config_file('userauth.kubeconfig'))
-    assert_equal(['localhost/system:admin:token', 'localhost/system:admin:userpass'],
+    assert_equal(['localhost/system:admin:token', 'localhost/system:admin:userpass', 'localhost/system:admin:gcptoken'],
                  config.contexts)
     context = config.context('localhost/system:admin:token')
     check_context(context, ssl: false)
@@ -35,12 +35,22 @@ class KubeClientConfigTest < MiniTest::Test
 
   def test_user_password
     config = Kubeclient::Config.read(test_config_file('userauth.kubeconfig'))
-    assert_equal(['localhost/system:admin:token', 'localhost/system:admin:userpass'],
+    assert_equal(['localhost/system:admin:token', 'localhost/system:admin:userpass', 'localhost/system:admin:gcptoken'],
                  config.contexts)
     context = config.context('localhost/system:admin:userpass')
     check_context(context, ssl: false)
     assert_equal('admin', context.auth_options[:username])
     assert_equal('pAssw0rd123', context.auth_options[:password])
+  end
+
+  def test_gcp_token
+    config = Kubeclient::Config.read(test_config_file('userauth.kubeconfig'))
+    assert_equal(['localhost/system:admin:token', 'localhost/system:admin:userpass', 'localhost/system:admin:gcptoken'],
+                 config.contexts)
+    context = config.context('localhost/system:admin:gcptoken')
+    check_context(context, ssl: false)
+    assert_equal('ya29.C0987654321QWERTYUIOPW', context.auth_options[:bearer_token])
+    assert_equal(Time.new(2016, 11, 11, 13, 11, 5.0, '+00:00'), context.auth_options[:bearer_token_expiry])
   end
 
   private

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -2,6 +2,18 @@ require 'test_helper'
 
 # Kubernetes client entity tests
 class KubeClientTest < MiniTest::Test
+
+  class RestClientResponseStub < String
+    def initialize(body, code)
+      @code = code
+      super(body)
+    end
+
+    def code
+      @code
+    end
+  end
+
   def test_json
     our_object = Kubeclient::Resource.new
     our_object.foo = 'bar'
@@ -389,11 +401,13 @@ class KubeClientTest < MiniTest::Test
   def test_api_bearer_token_failure
     error_message = '"/api/v1" is forbidden because ' \
                     'system:anonymous cannot list on pods in'
-    response = OpenStruct.new(code: 401, message: error_message)
+    response = RestClientResponseStub.new('', 403)
+    exception = RestClient::Exception.new(response)
+    exception.message = error_message
 
     stub_request(:get, 'http://localhost:8080/api/v1')
       .with(headers: { Authorization: 'Bearer invalid_token' })
-      .to_raise(KubeException.new(403, error_message, response))
+      .to_raise(exception)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/',
                                     auth_options: {
@@ -403,6 +417,31 @@ class KubeClientTest < MiniTest::Test
     exception = assert_raises(KubeException) { client.get_pods }
     assert_equal(403, exception.error_code)
     assert_equal(error_message, exception.message)
+    assert_equal(response, exception.response)
+  end
+
+  def test_api_bearer_token_expired
+    error_message = '401 Unauthorized'
+    response = RestClientResponseStub.new('Unauthorized', 401)
+    exception = RestClient::Exception.new(response)
+    exception.message = error_message
+
+    stub_request(:get, 'http://localhost:8080/api/v1')
+        .with(headers: { Authorization: 'Bearer expired_token' })
+        .to_raise(exception)
+
+    client = Kubeclient::Client.new 'http://localhost:8080/api/',
+                                    auth_options: {
+                                      bearer_token: 'expired_token',
+                                      bearer_token_expiry: Time.at(Time.now.to_i - 1)
+                                    }
+
+    exception = assert_raises(KubeException) { client.get_pods }
+    assert_equal(401, exception.error_code)
+    assert_equal(
+        error_message + '. Your token has expired. If you are using `kubectl`, running any command should renew your token.',
+        exception.message
+    )
     assert_equal(response, exception.response)
   end
 
@@ -454,10 +493,12 @@ class KubeClientTest < MiniTest::Test
 
   def test_api_basic_auth_failure
     error_message = 'HTTP status code 401, 401 Unauthorized'
-    response = OpenStruct.new(code: 401, message: '401 Unauthorized')
+    response = RestClientResponseStub.new('401 Unauthorized', 401)
+    exception = RestClient::Exception.new(response)
+    exception.message = error_message
 
     stub_request(:get, 'http://username:password@localhost:8080/api/v1')
-      .to_raise(KubeException.new(401, error_message, response))
+      .to_raise(exception)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/',
                                     auth_options: {

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -2,15 +2,13 @@ require 'test_helper'
 
 # Kubernetes client entity tests
 class KubeClientTest < MiniTest::Test
-
+  # Used to stub responses from RestClient in exceptions
   class RestClientResponseStub < String
+    attr_reader :code
+
     def initialize(body, code)
       @code = code
       super(body)
-    end
-
-    def code
-      @code
     end
   end
 
@@ -427,8 +425,8 @@ class KubeClientTest < MiniTest::Test
     exception.message = error_message
 
     stub_request(:get, 'http://localhost:8080/api/v1')
-        .with(headers: { Authorization: 'Bearer expired_token' })
-        .to_raise(exception)
+      .with(headers: { Authorization: 'Bearer expired_token' })
+      .to_raise(exception)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/',
                                     auth_options: {
@@ -439,8 +437,9 @@ class KubeClientTest < MiniTest::Test
     exception = assert_raises(KubeException) { client.get_pods }
     assert_equal(401, exception.error_code)
     assert_equal(
-        error_message + '. Your token has expired. If you are using `kubectl`, running any command should renew your token.',
-        exception.message
+      error_message + '. Your token has expired. If you are using `kubectl`, '\
+        'running any command should renew your token.',
+      exception.message
     )
     assert_equal(response, exception.response)
   end


### PR DESCRIPTION
This adds the ability to parse the bearer token from ~/.kube/config
stored by Google Cloud Platform. This token is only good for an hour
since it was last renewed with a `kubectl` command. So if a 401 error
is returned adds a note to the exception message when the token is
expired.

Also updates other auth failure tests that were bypassing exception
parsing in `Kubeclient::ClientMixing#handle_exception`.

Addresses #210 