### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -1,4 +1,4 @@
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '2.2.0'
+  VERSION = '2.3.0'
 end


### PR DESCRIPTION
Bumping gem version in order to expose backward compatibility introduced in https://github.com/abonas/kubeclient/pull/214. 
@simon3z @moolitayer 