### PR TITLE
Include request info in exceptions to make it easy to see what reques…

### DIFF
--- a/lib/kubeclient/kube_exception.rb
+++ b/lib/kubeclient/kube_exception.rb
@@ -9,6 +9,10 @@ class KubeException < StandardError
   end
 
   def to_s
-    'HTTP status code ' + @error_code.to_s + ', ' + @message
+    string = "HTTP status code #{@error_code}, #{@message}"
+    if @response.is_a?(RestClient::Response) && @response.request
+      string << " for #{@response.request.method.upcase} #{@response.request.url}"
+    end
+    string
   end
 end

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -79,6 +79,8 @@ class KubeClientTest < MiniTest::Test
     assert_instance_of(KubeException, exception)
     assert_equal("converting  to : type names don't match (Pod, Namespace)",
                  exception.message)
+
+    assert_includes(exception.to_s, ' for POST http://localhost:8080/api')
     assert_equal(409, exception.error_code)
   end
 


### PR DESCRIPTION
…t and what server failed

we are doing a lot of requests to a lot of different servers, so a general "This failed" exception is not helpful.

```
Kubernetes::Cluster.last.client.get_secret 'sdfsdfs'
KubeException: HTTP status code 404 the server could not find the requested resource for GET https://k8s-sandbox.consul:8443/api/v1/secrets/sdfsdfs
  from kubeclient/common.rb:107:in `rescue in handle_exception'
```

@abonas