### PR TITLE
bump rubocop, fix offenses, use 2-space indent

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+AllCops:
+  DisplayCopNames: true
 MethodLength:
   Enabled: false
 ClassLength:
@@ -10,3 +12,5 @@ Metrics/ParameterLists:
   Max: 8
 Metrics/CyclomaticComplexity:
   Max: 8
+Metrics/ModuleLength:
+  Enabled: false

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'webmock', '~> 1.24.2'
   spec.add_development_dependency 'vcr'
-  spec.add_development_dependency 'rubocop', '= 0.30.0'
+  spec.add_development_dependency 'rubocop', '= 0.46.0'
   spec.add_dependency 'rest-client'
   spec.add_dependency 'recursive-open-struct', '= 1.0.0'
   spec.add_dependency 'http', '= 0.9.8'

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -20,7 +20,7 @@ module Kubeclient
     def initialize(kcfg, kcfg_path)
       @kcfg = kcfg
       @kcfg_path = kcfg_path
-      fail 'Unknown kubeconfig version' if @kcfg['apiVersion'] != 'v1'
+      raise 'Unknown kubeconfig version' if @kcfg['apiVersion'] != 'v1'
     end
 
     def self.read(filename)
@@ -72,13 +72,13 @@ module Kubeclient
         break x['context'] if x['name'] == context_name
       end
 
-      fail "Unknown context #{context_name}" unless context
+      raise "Unknown context #{context_name}" unless context
 
       cluster = @kcfg['clusters'].detect do |x|
         break x['cluster'] if x['name'] == context['cluster']
       end
 
-      fail "Unknown cluster #{context['cluster']}" unless cluster
+      raise "Unknown cluster #{context['cluster']}" unless cluster
 
       user = @kcfg['users'].detect do |x|
         break x['user'] if x['name'] == context['user']
@@ -89,25 +89,25 @@ module Kubeclient
 
     def fetch_cluster_ca_data(cluster)
       if cluster.key?('certificate-authority')
-        return File.read(ext_file_path(cluster['certificate-authority']))
+        File.read(ext_file_path(cluster['certificate-authority']))
       elsif cluster.key?('certificate-authority-data')
-        return Base64.decode64(cluster['certificate-authority-data'])
+        Base64.decode64(cluster['certificate-authority-data'])
       end
     end
 
     def fetch_user_cert_data(user)
       if user.key?('client-certificate')
-        return File.read(ext_file_path(user['client-certificate']))
+        File.read(ext_file_path(user['client-certificate']))
       elsif user.key?('client-certificate-data')
-        return Base64.decode64(user['client-certificate-data'])
+        Base64.decode64(user['client-certificate-data'])
       end
     end
 
     def fetch_user_key_data(user)
       if user.key?('client-key')
-        return File.read(ext_file_path(user['client-key']))
+        File.read(ext_file_path(user['client-key']))
       elsif user.key?('client-key-data')
-        return Base64.decode64(user['client-key-data'])
+        Base64.decode64(user['client-key-data'])
       end
     end
 

--- a/lib/kubeclient/missing_kind_compatibility.rb
+++ b/lib/kubeclient/missing_kind_compatibility.rb
@@ -58,7 +58,7 @@ module Kubeclient
         'templates'                  => 'Template',
         'useridentitymappings'       => 'UserIdentityMapping',
         'users'                      => 'User'
-      }
+      }.freeze
 
       def self.resource_kind(name)
         MAPPING[name]

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -1,4 +1,4 @@
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '2.3.0'
+  VERSION = '2.3.0'.freeze
 end

--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -17,7 +17,7 @@ module Kubeclient
         @http_client = build_client
         response = @http_client.request(:get, @uri, build_client_options)
         unless response.code < 300
-          fail KubeException.new(response.code, response.reason, response)
+          raise KubeException.new(response.code, response.reason, response)
         end
 
         buffer = ''
@@ -40,8 +40,10 @@ module Kubeclient
 
       def build_client
         if @http_options[:basic_auth_user] && @http_options[:basic_auth_password]
-          HTTP.basic_auth(user: @http_options[:basic_auth_user],
-                          pass: @http_options[:basic_auth_password])
+          HTTP.basic_auth(
+            user: @http_options[:basic_auth_user],
+            pass: @http_options[:basic_auth_password]
+          )
         else
           HTTP::Client.new
         end
@@ -66,12 +68,11 @@ module Kubeclient
         }
         if @http_options[:ssl]
           client_options[:ssl] = @http_options[:ssl]
-          client_options[:ssl_socket_class] =
-              @http_options[:ssl_socket_class] if @http_options[:ssl_socket_class]
+          socket_option = :ssl_socket_class
         else
-          client_options[:socket_class] =
-              @http_options[:socket_class] if @http_options[:socket_class]
+          socket_option = :socket_class
         end
+        client_options[socket_option] = @http_options[socket_option] if @http_options[socket_option]
         client_options
       end
     end

--- a/test/test_component_status.rb
+++ b/test/test_component_status.rb
@@ -4,11 +4,9 @@ require 'test_helper'
 class TestComponentStatus < MiniTest::Test
   def test_get_from_json_v3
     stub_request(:get, %r{/componentstatuses})
-      .to_return(body: open_test_file('component_status.json'),
-                 status: 200)
+      .to_return(body: open_test_file('component_status.json'), status: 200)
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     component_status = client.get_component_status 'etcd-0', 'default'
@@ -18,11 +16,15 @@ class TestComponentStatus < MiniTest::Test
     assert_equal('Healthy', component_status.conditions[0].type)
     assert_equal('True', component_status.conditions[0].status)
 
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1',
-                     times: 1)
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1/namespaces/default/componentstatuses/etcd-0',
-                     times: 1)
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1',
+      times: 1
+    )
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1/namespaces/default/componentstatuses/etcd-0',
+      times: 1
+    )
   end
 end

--- a/test/test_endpoint.rb
+++ b/test/test_endpoint.rb
@@ -4,22 +4,26 @@ require 'test_helper'
 class TestEndpoint < MiniTest::Test
   def test_create_endpoint
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(
+        body: open_test_file('core_api_resource_list.json'),
+        status: 200
+      )
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     testing_ep = Kubeclient::Resource.new
     testing_ep.metadata = {}
     testing_ep.metadata.name = 'myendpoint'
     testing_ep.metadata.namespace = 'default'
-    testing_ep.subsets = [{ 'addresses' => [{ 'ip' => '172.17.0.25' }], 'ports' =>
-                              [{ 'name' => 'https',
-                                 'port' => 6443,
-                                 'protocol' => 'TCP' }] }]
+    testing_ep.subsets = [
+      {
+        'addresses' => [{ 'ip' => '172.17.0.25' }],
+        'ports' => [{ 'name' => 'https', 'port' => 6443, 'protocol' => 'TCP' }]
+      }
+    ]
 
-    req_body = "{\"metadata\":{\"name\":\"myendpoint\",\"namespace\":\"default\"}," \
-        "\"subsets\":[{\"addresses\":[{\"ip\":\"172.17.0.25\"}],\"ports\":[{\"name\":\"https\"," \
-    "\"port\":6443,\"protocol\":\"TCP\"}]}],\"kind\":\"Endpoints\",\"apiVersion\":\"v1\"}"
+    req_body = '{"metadata":{"name":"myendpoint","namespace":"default"},' \
+      '"subsets":[{"addresses":[{"ip":"172.17.0.25"}],"ports":[{"name":"https",' \
+      '"port":6443,"protocol":"TCP"}]}],"kind":"Endpoints","apiVersion":"v1"}'
 
     stub_request(:post, 'http://localhost:8080/api/v1/namespaces/default/endpoints')
       .with(body: req_body)

--- a/test/test_guestbook_go.rb
+++ b/test/test_guestbook_go.rb
@@ -19,10 +19,14 @@ class CreateGuestbookGo < MiniTest::Test
 
       # delete in case they existed before so creation can be tested
       delete_namespace(client, testing_ns.metadata.name)
-      delete_services(client, testing_ns.metadata.name,
-                      ['guestbook', 'redis-master', 'redis-slave'])
-      delete_replication_controllers(client, testing_ns.metadata.name,
-                                     ['guestbook', 'redis-master', 'redis-slave'])
+      delete_services(
+        client, testing_ns.metadata.name,
+        ['guestbook', 'redis-master', 'redis-slave']
+      )
+      delete_replication_controllers(
+        client, testing_ns.metadata.name,
+        ['guestbook', 'redis-master', 'redis-slave']
+      )
 
       client.create_namespace testing_ns
       services = create_services(client, testing_ns.metadata.name)
@@ -41,9 +45,9 @@ class CreateGuestbookGo < MiniTest::Test
 
   def delete_namespace(client, namespace_name)
     client.delete_namespace namespace_name
-    rescue KubeException => exception
-      assert_instance_of(KubeException, exception)
-      assert_equal(404, exception.error_code)
+  rescue KubeException => exception
+    assert_instance_of(KubeException, exception)
+    assert_equal(404, exception.error_code)
   end
 
   def get_namespaces(client)
@@ -135,10 +139,14 @@ class CreateGuestbookGo < MiniTest::Test
     rc.spec.selector.role = 'master'
     rc.spec.template.metadata.labels.app = 'redis'
     rc.spec.template.metadata.labels.role = 'master'
-    rc.spec.template.spec.containers = [{ 'name' => 'redis-master',
-                                          'image' => 'redis',
-                                          'ports' => [{ 'name' => 'redis-server',
-                                                        'containerPort' => 6379 }] }]
+    rc.spec.template.spec.containers = [{
+      'name' => 'redis-master',
+      'image' => 'redis',
+      'ports' => [{
+        'name' => 'redis-server',
+        'containerPort' => 6379
+      }]
+    }]
     rc
   end
 
@@ -152,11 +160,14 @@ class CreateGuestbookGo < MiniTest::Test
     rc.spec.selector.role = 'slave'
     rc.spec.template.metadata.labels.app = 'redis'
     rc.spec.template.metadata.labels.role = 'slave'
-    rc.spec.template.spec.containers = [{ 'name'          => 'redis-slave',
-                                          'image'         => 'kubernetes/redis-slave:v2',
-                                          'ports'         => [{ 'name'          => 'redis-server',
-                                                                'containerPort' => 6379 }
-                                                             ] }]
+    rc.spec.template.spec.containers = [{
+      'name'          => 'redis-slave',
+      'image'         => 'kubernetes/redis-slave:v2',
+      'ports'         => [{
+        'name'          => 'redis-server',
+        'containerPort' => 6379
+      }]
+    }]
     rc
   end
 
@@ -168,12 +179,18 @@ class CreateGuestbookGo < MiniTest::Test
     rc.spec.replicas = 3
     rc.spec.selector.app = 'guestbook'
     rc.spec.template.metadata.labels.app = 'guestbook'
-    rc.spec.template.spec.containers = [{ 'name'     => 'guestbook',
-                                          'image'    => 'kubernetes/guestbook:v2',
-                                          'ports'    => [{ 'name'          => 'http-server',
-                                                           'containerPort' => 3000 }]
-                                        }]
-
+    rc.spec.template.spec.containers = [
+      {
+        'name'     => 'guestbook',
+        'image'    => 'kubernetes/guestbook:v2',
+        'ports'    => [
+          {
+            'name'          => 'http-server',
+            'containerPort' => 3000
+          }
+        ]
+      }
+    ]
     rc
   end
 
@@ -192,11 +209,7 @@ class CreateGuestbookGo < MiniTest::Test
     our_service.metadata.name = 'redis-slave'
     our_service.metadata.labels.app = 'redis'
     our_service.metadata.labels.role = 'slave'
-
-    our_service.spec.ports = [{ 'port' => 6379,
-                                'targetPort' => 'redis-server'
-                              }]
-
+    our_service.spec.ports = [{ 'port' => 6379, 'targetPort' => 'redis-server' }]
     our_service.spec.selector.app = 'redis'
     our_service.spec.selector.role = 'slave'
     our_service
@@ -207,11 +220,7 @@ class CreateGuestbookGo < MiniTest::Test
     our_service.metadata.name = 'redis-master'
     our_service.metadata.labels.app = 'redis'
     our_service.metadata.labels.role = 'master'
-
-    our_service.spec.ports = [{ 'port' => 6379,
-                                'targetPort' => 'redis-server'
-                              }]
-
+    our_service.spec.ports = [{ 'port' => 6379, 'targetPort' => 'redis-server' }]
     our_service.spec.selector.app = 'redis'
     our_service.spec.selector.role = 'master'
     our_service
@@ -221,11 +230,7 @@ class CreateGuestbookGo < MiniTest::Test
     our_service = base_service(namespace)
     our_service.metadata.name = 'guestbook'
     our_service.metadata.labels.name = 'guestbook'
-
-    our_service.spec.ports = [{ 'port' => 3000,
-                                'targetPort' => 'http-server'
-                              }]
-
+    our_service.spec.ports = [{ 'port' => 3000, 'targetPort' => 'http-server' }]
     our_service.spec.selector.app = 'guestbook'
     our_service.type = 'LoadBalancer'
     our_service

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -10,8 +10,10 @@ class KubeClientTest < MiniTest::Test
     our_object.nested.again.again = {}
     our_object.nested.again.again.name = 'aaron'
 
-    expected = { 'foo' => 'bar', 'nested' => { 'again' => { 'again' =>
-                 { 'name' => 'aaron' } } } }
+    expected = {
+      'foo' => 'bar',
+      'nested' => { 'again' => { 'again' => { 'name' => 'aaron' } } }
+    }
 
     assert_equal(expected, JSON.parse(JSON.dump(our_object.to_h)))
   end
@@ -42,8 +44,7 @@ class KubeClientTest < MiniTest::Test
     uri = URI::HTTP.build(host: 'localhost', port: 8080)
     proxy_uri = URI::HTTP.build(host: 'myproxyhost', port: 8888)
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new(uri, http_proxy_uri: proxy_uri)
     rest_client = client.rest_client
@@ -56,11 +57,9 @@ class KubeClientTest < MiniTest::Test
 
   def test_exception
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:post, %r{/services})
-      .to_return(body: open_test_file('namespace_exception.json'),
-                 status: 409)
+      .to_return(body: open_test_file('namespace_exception.json'), status: 409)
 
     service = Kubeclient::Resource.new
     service.metadata = {}
@@ -157,11 +156,9 @@ class KubeClientTest < MiniTest::Test
 
   def test_nonjson_exception
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:get, %r{/servic})
-      .to_return(body: open_test_file('service_illegal_json_404.json'),
-                 status: 404)
+      .to_return(body: open_test_file('service_illegal_json_404.json'), status: 404)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
 
@@ -176,11 +173,9 @@ class KubeClientTest < MiniTest::Test
 
   def test_entity_list
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:get, %r{/services})
-      .to_return(body: open_test_file('entity_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('entity_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     services = client.get_services
@@ -192,56 +187,52 @@ class KubeClientTest < MiniTest::Test
     assert_instance_of(Kubeclient::Service, services[0])
     assert_instance_of(Kubeclient::Service, services[1])
 
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1/services',
-                     times: 1)
+    assert_requested(:get, 'http://localhost:8080/api/v1/services', times: 1)
   end
 
   def test_entities_with_label_selector
     selector = 'component=apiserver'
 
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:get, %r{/services})
-      .to_return(body: open_test_file('entity_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('entity_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     services = client.get_services(label_selector: selector)
 
     assert_instance_of(Kubeclient::Common::EntityList, services)
-    assert_requested(:get,
-                     "http://localhost:8080/api/v1/services?labelSelector=#{selector}",
-                     times: 1)
+    assert_requested(
+      :get,
+      "http://localhost:8080/api/v1/services?labelSelector=#{selector}",
+      times: 1
+    )
   end
 
   def test_entities_with_field_selector
     selector = 'involvedObject.name=redis-master'
 
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:get, %r{/services})
-      .to_return(body: open_test_file('entity_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('entity_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     services = client.get_services(field_selector: selector)
 
     assert_instance_of(Kubeclient::Common::EntityList, services)
-    assert_requested(:get,
-                     "http://localhost:8080/api/v1/services?fieldSelector=#{selector}",
-                     times: 1)
+    assert_requested(
+      :get,
+      "http://localhost:8080/api/v1/services?fieldSelector=#{selector}",
+      times: 1
+    )
   end
 
   def test_empty_list
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:get, %r{/pods})
-      .to_return(body: open_test_file('empty_pod_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('empty_pod_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     pods = client.get_pods
@@ -251,32 +242,25 @@ class KubeClientTest < MiniTest::Test
 
   def test_get_all
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     stub_request(:get, %r{/bindings})
-      .to_return(body: open_test_file('bindings_list.json'),
-                 status: 404)
+      .to_return(body: open_test_file('bindings_list.json'), status: 404)
 
     stub_request(:get, %r{/configmaps})
-      .to_return(body: open_test_file('config_map_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('config_map_list.json'), status: 200)
 
     stub_request(:get, %r{/podtemplates})
-      .to_return(body: open_test_file('pod_template_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('pod_template_list.json'), status: 200)
 
     stub_request(:get, %r{/services})
-      .to_return(body: open_test_file('service_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('service_list.json'), status: 200)
 
     stub_request(:get, %r{/pods})
-      .to_return(body: open_test_file('pod_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('pod_list.json'), status: 200)
 
     stub_request(:get, %r{/nodes})
-      .to_return(body: open_test_file('node_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('node_list.json'), status: 200)
 
     stub_request(:get, %r{/replicationcontrollers})
       .to_return(body: open_test_file('replication_controller_list.json'), status: 200)
@@ -285,48 +269,38 @@ class KubeClientTest < MiniTest::Test
       .to_return(body: open_test_file('event_list.json'), status: 200)
 
     stub_request(:get, %r{/endpoints})
-      .to_return(body: open_test_file('endpoint_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('endpoint_list.json'), status: 200)
 
     stub_request(:get, %r{/namespaces})
-      .to_return(body: open_test_file('namespace_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('namespace_list.json'), status: 200)
 
     stub_request(:get, %r{/secrets})
-      .to_return(body: open_test_file('secret_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('secret_list.json'), status: 200)
 
     stub_request(:get, %r{/resourcequotas})
-      .to_return(body: open_test_file('resource_quota_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('resource_quota_list.json'), status: 200)
 
     stub_request(:get, %r{/limitranges})
-      .to_return(body: open_test_file('limit_range_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('limit_range_list.json'), status: 200)
 
     stub_request(:get, %r{/persistentvolumes})
-      .to_return(body: open_test_file('persistent_volume_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('persistent_volume_list.json'), status: 200)
 
     stub_request(:get, %r{/persistentvolumeclaims})
-      .to_return(body: open_test_file('persistent_volume_claim_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('persistent_volume_claim_list.json'), status: 200)
 
     stub_request(:get, %r{/componentstatuses})
-      .to_return(body: open_test_file('component_status_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('component_status_list.json'), status: 200)
 
     stub_request(:get, %r{/serviceaccounts})
-      .to_return(body: open_test_file('service_account_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('service_account_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     result = client.all_entities
     assert_equal(16, result.keys.size)
     assert_instance_of(Kubeclient::Common::EntityList, result['node'])
     assert_instance_of(Kubeclient::Common::EntityList, result['service'])
-    assert_instance_of(Kubeclient::Common::EntityList,
-                       result['replication_controller'])
+    assert_instance_of(Kubeclient::Common::EntityList, result['replication_controller'])
     assert_instance_of(Kubeclient::Common::EntityList, result['pod'])
     assert_instance_of(Kubeclient::Common::EntityList, result['event'])
     assert_instance_of(Kubeclient::Common::EntityList, result['namespace'])
@@ -348,17 +322,15 @@ class KubeClientTest < MiniTest::Test
   def test_api_bearer_token_with_params_success
     stub_request(:get, 'http://localhost:8080/api/v1/pods?labelSelector=name=redis-master')
       .with(headers: { Authorization: 'Bearer valid_token' })
-      .to_return(body: open_test_file('pod_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('pod_list.json'), status: 200)
     stub_request(:get, %r{/api/v1$})
       .with(headers: { Authorization: 'Bearer valid_token' })
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
-    client = Kubeclient::Client.new('http://localhost:8080/api/',
-                                    auth_options: {
-                                      bearer_token: 'valid_token'
-                                    })
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/',
+      auth_options: { bearer_token: 'valid_token' }
+    )
 
     pods = client.get_pods(label_selector: 'name=redis-master')
 
@@ -368,17 +340,19 @@ class KubeClientTest < MiniTest::Test
 
   def test_api_bearer_token_success
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(
+        body: open_test_file('core_api_resource_list.json'), status: 200
+      )
     stub_request(:get, 'http://localhost:8080/api/v1/pods')
       .with(headers: { Authorization: 'Bearer valid_token' })
-      .to_return(body: open_test_file('pod_list.json'),
-                 status: 200)
+      .to_return(
+        body: open_test_file('pod_list.json'), status: 200
+      )
 
-    client = Kubeclient::Client.new('http://localhost:8080/api/',
-                                    auth_options: {
-                                      bearer_token: 'valid_token'
-                                    })
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/',
+      auth_options: { bearer_token: 'valid_token' }
+    )
 
     pods = client.get_pods
 
@@ -387,18 +361,19 @@ class KubeClientTest < MiniTest::Test
   end
 
   def test_api_bearer_token_failure
-    error_message = '"/api/v1" is forbidden because ' \
-                    'system:anonymous cannot list on pods in'
+    error_message =
+      '"/api/v1" is forbidden because ' \
+      'system:anonymous cannot list on pods in'
     response = OpenStruct.new(code: 401, message: error_message)
 
     stub_request(:get, 'http://localhost:8080/api/v1')
       .with(headers: { Authorization: 'Bearer invalid_token' })
       .to_raise(KubeException.new(403, error_message, response))
 
-    client = Kubeclient::Client.new('http://localhost:8080/api/',
-                                    auth_options: {
-                                      bearer_token: 'invalid_token'
-                                    })
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/',
+      auth_options: { bearer_token: 'invalid_token' }
+    )
 
     exception = assert_raises(KubeException) { client.get_pods }
     assert_equal(403, exception.error_code)
@@ -408,48 +383,42 @@ class KubeClientTest < MiniTest::Test
 
   def test_api_basic_auth_success
     stub_request(:get, 'http://username:password@localhost:8080/api/v1')
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:get, 'http://username:password@localhost:8080/api/v1/pods')
-      .to_return(body: open_test_file('pod_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('pod_list.json'), status: 200)
 
-    client = Kubeclient::Client.new('http://localhost:8080/api/',
-                                    auth_options: {
-                                      username: 'username',
-                                      password: 'password'
-                                    })
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/',
+      auth_options: { username: 'username', password: 'password' }
+    )
 
     pods = client.get_pods
 
     assert_equal('Pod', pods.kind)
     assert_equal(1, pods.size)
-    assert_requested(:get,
-                     'http://username:password@localhost:8080/api/v1/pods',
-                     times: 1)
+    assert_requested(
+      :get,
+      'http://username:password@localhost:8080/api/v1/pods',
+      times: 1
+    )
   end
 
   def test_api_basic_auth_back_comp_success
     stub_request(:get, 'http://username:password@localhost:8080/api/v1')
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:get, 'http://username:password@localhost:8080/api/v1/pods')
-      .to_return(body: open_test_file('pod_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('pod_list.json'), status: 200)
 
-    client = Kubeclient::Client.new('http://localhost:8080/api/',
-                                    auth_options: {
-                                      user: 'username',
-                                      password: 'password'
-                                    })
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/',
+      auth_options: { user: 'username', password: 'password' }
+    )
 
     pods = client.get_pods
 
     assert_equal('Pod', pods.kind)
     assert_equal(1, pods.size)
-    assert_requested(:get,
-                     'http://username:password@localhost:8080/api/v1/pods',
-                     times: 1)
+    assert_requested(:get, 'http://username:password@localhost:8080/api/v1/pods', times: 1)
   end
 
   def test_api_basic_auth_failure
@@ -459,28 +428,25 @@ class KubeClientTest < MiniTest::Test
     stub_request(:get, 'http://username:password@localhost:8080/api/v1')
       .to_raise(KubeException.new(401, error_message, response))
 
-    client = Kubeclient::Client.new('http://localhost:8080/api/',
-                                    auth_options: {
-                                      username: 'username',
-                                      password: 'password'
-                                    })
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/',
+      auth_options: { username: 'username', password: 'password' }
+    )
 
     exception = assert_raises(KubeException) { client.get_pods }
     assert_equal(401, exception.error_code)
     assert_equal(error_message, exception.message)
     assert_equal(response, exception.response)
-    assert_requested(:get,
-                     'http://username:password@localhost:8080/api/v1',
-                     times: 1)
+    assert_requested(:get, 'http://username:password@localhost:8080/api/v1', times: 1)
   end
 
   def test_init_username_no_password
     expected_msg = 'Basic auth requires both username & password'
     exception = assert_raises(ArgumentError) do
-      Kubeclient::Client.new('http://localhost:8080',
-                             auth_options: {
-                               username: 'username'
-                             })
+      Kubeclient::Client.new(
+        'http://localhost:8080',
+        auth_options: { username: 'username' }
+      )
     end
     assert_equal(expected_msg, exception.message)
   end
@@ -488,49 +454,47 @@ class KubeClientTest < MiniTest::Test
   def test_init_user_no_password
     expected_msg = 'Basic auth requires both username & password'
     exception = assert_raises(ArgumentError) do
-      Kubeclient::Client.new('http://localhost:8080',
-                             auth_options: {
-                               user: 'username'
-                             })
+      Kubeclient::Client.new(
+        'http://localhost:8080',
+        auth_options: { user: 'username' }
+      )
     end
     assert_equal(expected_msg, exception.message)
   end
 
   def test_init_username_and_bearer_token
     expected_msg = 'Invalid auth options: specify only one of username/password,' \
-                   ' bearer_token or bearer_token_file'
+      ' bearer_token or bearer_token_file'
     exception = assert_raises(ArgumentError) do
-      Kubeclient::Client.new('http://localhost:8080',
-                             auth_options: {
-                               username: 'username',
-                               bearer_token: 'token'
-                             })
+      Kubeclient::Client.new(
+        'http://localhost:8080',
+        auth_options: { username: 'username', bearer_token: 'token' }
+      )
     end
     assert_equal(expected_msg, exception.message)
   end
 
   def test_init_user_and_bearer_token
     expected_msg = 'Invalid auth options: specify only one of username/password,' \
-                   ' bearer_token or bearer_token_file'
+      ' bearer_token or bearer_token_file'
     exception = assert_raises(ArgumentError) do
-      Kubeclient::Client.new('http://localhost:8080',
-                             auth_options: {
-                               username: 'username',
-                               bearer_token: 'token'
-                             })
+      Kubeclient::Client.new(
+        'http://localhost:8080',
+        auth_options: { username: 'username', bearer_token: 'token' }
+      )
     end
     assert_equal(expected_msg, exception.message)
   end
 
   def test_bearer_token_and_bearer_token_file
-    expected_msg = 'Invalid auth options: specify only one of username/password,' \
-                   ' bearer_token or bearer_token_file'
+    expected_msg =
+      'Invalid auth options: specify only one of username/password,' \
+      ' bearer_token or bearer_token_file'
     exception = assert_raises(ArgumentError) do
-      Kubeclient::Client.new('http://localhost:8080',
-                             auth_options: {
-                               bearer_token: 'token',
-                               bearer_token_file: 'token-file'
-                             })
+      Kubeclient::Client.new(
+        'http://localhost:8080',
+        auth_options: { bearer_token: 'token', bearer_token_file: 'token-file' }
+      )
     end
     assert_equal(expected_msg, exception.message)
   end
@@ -538,28 +502,26 @@ class KubeClientTest < MiniTest::Test
   def test_bearer_token_file_not_exist
     expected_msg = 'Token file token-file does not exist'
     exception = assert_raises(ArgumentError) do
-      Kubeclient::Client.new('http://localhost:8080',
-                             auth_options: {
-                               bearer_token_file: 'token-file'
-                             })
+      Kubeclient::Client.new(
+        'http://localhost:8080',
+        auth_options: { bearer_token_file: 'token-file' }
+      )
     end
     assert_equal(expected_msg, exception.message)
   end
 
   def test_api_bearer_token_file_success
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:get, 'http://localhost:8080/api/v1/pods')
       .with(headers: { Authorization: 'Bearer valid_token' })
-      .to_return(body: open_test_file('pod_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('pod_list.json'), status: 200)
 
     file = File.join(File.dirname(__FILE__), 'valid_token_file')
-    client = Kubeclient::Client.new('http://localhost:8080/api/',
-                                    auth_options: {
-                                      bearer_token_file: file
-                                    })
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/',
+      auth_options: { bearer_token_file: file }
+    )
 
     pods = client.get_pods
 
@@ -569,45 +531,58 @@ class KubeClientTest < MiniTest::Test
 
   def test_proxy_url
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://host:8080', 'v1')
-    assert_equal('http://host:8080/api/v1/proxy/namespaces/ns/services/srvname:srvportname',
-                 client.proxy_url('service', 'srvname', 'srvportname', 'ns'))
+    assert_equal(
+      'http://host:8080/api/v1/proxy/namespaces/ns/services/srvname:srvportname',
+      client.proxy_url('service', 'srvname', 'srvportname', 'ns')
+    )
 
-    assert_equal('http://host:8080/api/v1/proxy/namespaces/ns/services/srvname:srvportname',
-                 client.proxy_url('services', 'srvname', 'srvportname', 'ns'))
+    assert_equal(
+      'http://host:8080/api/v1/proxy/namespaces/ns/services/srvname:srvportname',
+      client.proxy_url('services', 'srvname', 'srvportname', 'ns')
+    )
 
-    assert_equal('http://host:8080/api/v1/namespaces/ns/pods/srvname:srvportname/proxy',
-                 client.proxy_url('pod', 'srvname', 'srvportname', 'ns'))
+    assert_equal(
+      'http://host:8080/api/v1/namespaces/ns/pods/srvname:srvportname/proxy',
+      client.proxy_url('pod', 'srvname', 'srvportname', 'ns')
+    )
 
-    assert_equal('http://host:8080/api/v1/namespaces/ns/pods/srvname:srvportname/proxy',
-                 client.proxy_url('pods', 'srvname', 'srvportname', 'ns'))
+    assert_equal(
+      'http://host:8080/api/v1/namespaces/ns/pods/srvname:srvportname/proxy',
+      client.proxy_url('pods', 'srvname', 'srvportname', 'ns')
+    )
 
     # Check no namespace provided
-    assert_equal('http://host:8080/api/v1/proxy/nodes/srvname:srvportname',
-                 client.proxy_url('nodes', 'srvname', 'srvportname'))
+    assert_equal(
+      'http://host:8080/api/v1/proxy/nodes/srvname:srvportname',
+      client.proxy_url('nodes', 'srvname', 'srvportname')
+    )
 
-    assert_equal('http://host:8080/api/v1/proxy/nodes/srvname:srvportname',
-                 client.proxy_url('node', 'srvname', 'srvportname'))
+    assert_equal(
+      'http://host:8080/api/v1/proxy/nodes/srvname:srvportname',
+      client.proxy_url('node', 'srvname', 'srvportname')
+    )
 
     # Check integer port
-    assert_equal('http://host:8080/api/v1/proxy/nodes/srvname:5001',
-                 client.proxy_url('nodes', 'srvname', 5001))
+    assert_equal(
+      'http://host:8080/api/v1/proxy/nodes/srvname:5001',
+      client.proxy_url('nodes', 'srvname', 5001)
+    )
 
-    assert_equal('http://host:8080/api/v1/proxy/nodes/srvname:5001',
-                 client.proxy_url('node', 'srvname', 5001))
+    assert_equal(
+      'http://host:8080/api/v1/proxy/nodes/srvname:5001',
+      client.proxy_url('node', 'srvname', 5001)
+    )
   end
 
   def test_attr_readers
-    client = Kubeclient::Client.new('http://localhost:8080/api/',
-                                    ssl_options: {
-                                      client_key: 'secret'
-                                    },
-                                    auth_options: {
-                                      bearer_token: 'token'
-                                    })
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/',
+      ssl_options: { client_key: 'secret' },
+      auth_options: { bearer_token: 'token' }
+    )
     assert_equal('/api', client.api_endpoint.path)
     assert_equal('secret', client.ssl_options[:client_key])
     assert_equal('token', client.auth_options[:bearer_token])
@@ -617,11 +592,9 @@ class KubeClientTest < MiniTest::Test
   def test_nil_items
     # handle https://github.com/kubernetes/kubernetes/issues/13096
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:get, %r{/persistentvolumeclaims})
-      .to_return(body: open_test_file('persistent_volume_claims_nil_items.json'),
-                 status: 200)
+      .to_return(body: open_test_file('persistent_volume_claims_nil_items.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     client.get_persistent_volume_claims

--- a/test/test_limit_range.rb
+++ b/test/test_limit_range.rb
@@ -4,12 +4,10 @@ require 'test_helper'
 class TestLimitRange < MiniTest::Test
   def test_get_from_json_v1
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     stub_request(:get, %r{/limitranges})
-      .to_return(body: open_test_file('limit_range.json'),
-                 status: 200)
+      .to_return(body: open_test_file('limit_range.json'), status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     limit_range = client.get_limit_range 'limits', 'quota-example'
@@ -20,8 +18,10 @@ class TestLimitRange < MiniTest::Test
     assert_equal('100m', limit_range.spec.limits[0].default.cpu)
     assert_equal('512Mi', limit_range.spec.limits[0].default.memory)
 
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1/namespaces/quota-example/limitranges/limits',
-                     times: 1)
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1/namespaces/quota-example/limitranges/limits',
+      times: 1
+    )
   end
 end

--- a/test/test_namespace.rb
+++ b/test/test_namespace.rb
@@ -4,11 +4,9 @@ require 'test_helper'
 class TestNamespace < MiniTest::Test
   def test_get_namespace_v1
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:get, %r{/namespaces})
-      .to_return(body: open_test_file('namespace.json'),
-                 status: 200)
+      .to_return(body: open_test_file('namespace.json'), status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     namespace = client.get_namespace 'staging'
@@ -19,9 +17,11 @@ class TestNamespace < MiniTest::Test
     assert_equal('1168', namespace.metadata.resourceVersion)
     assert_equal('v1', namespace.apiVersion)
 
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1/namespaces/staging',
-                     times: 1)
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1/namespaces/staging',
+      times: 1
+    )
   end
 
   def test_delete_namespace_v1
@@ -30,25 +30,24 @@ class TestNamespace < MiniTest::Test
     our_namespace.metadata.name = 'staging'
 
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:delete, %r{/namespaces})
       .to_return(status: 200)
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     client.delete_namespace our_namespace.metadata.name
 
-    assert_requested(:delete,
-                     'http://localhost:8080/api/v1/namespaces/staging',
-                     times: 1)
+    assert_requested(
+      :delete,
+      'http://localhost:8080/api/v1/namespaces/staging',
+      times: 1
+    )
   end
 
   def test_create_namespace
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:post, %r{/namespaces})
-      .to_return(body: open_test_file('created_namespace.json'),
-                 status: 201)
+      .to_return(body: open_test_file('created_namespace.json'), status: 201)
 
     namespace = Kubeclient::Resource.new
     namespace.metadata = {}

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -4,11 +4,9 @@ require 'test_helper'
 class TestNode < MiniTest::Test
   def test_get_from_json_v1
     stub_request(:get, %r{/nodes})
-      .to_return(body: open_test_file('node.json'),
-                 status: 200)
+      .to_return(body: open_test_file('node.json'), status: 200)
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     node = client.get_node('127.0.0.1')
@@ -21,11 +19,15 @@ class TestNode < MiniTest::Test
     assert_equal('v1', node.apiVersion)
     assert_equal('2015-03-19T15:08:20+02:00', node.metadata.creationTimestamp)
 
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1',
-                     times: 1)
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1/nodes/127.0.0.1',
-                     times: 1)
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1',
+      times: 1
+    )
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1/nodes/127.0.0.1',
+      times: 1
+    )
   end
 end

--- a/test/test_persistent_volume.rb
+++ b/test/test_persistent_volume.rb
@@ -4,11 +4,9 @@ require 'test_helper'
 class TestPersistentVolume < MiniTest::Test
   def test_get_from_json_v1
     stub_request(:get, %r{/persistentvolumes})
-      .to_return(body: open_test_file('persistent_volume.json'),
-                 status: 200)
+      .to_return(body: open_test_file('persistent_volume.json'), status: 200)
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     volume = client.get_persistent_volume 'pv0001'
@@ -18,11 +16,15 @@ class TestPersistentVolume < MiniTest::Test
     assert_equal('10Gi', volume.spec.capacity.storage)
     assert_equal('/tmp/data01', volume.spec.hostPath.path)
 
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1',
-                     times: 1)
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1/persistentvolumes/pv0001',
-                     times: 1)
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1',
+      times: 1
+    )
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1/persistentvolumes/pv0001',
+      times: 1
+    )
   end
 end

--- a/test/test_persistent_volume_claim.rb
+++ b/test/test_persistent_volume_claim.rb
@@ -4,11 +4,9 @@ require 'test_helper'
 class TestPersistentVolumeClaim < MiniTest::Test
   def test_get_from_json_v1
     stub_request(:get, %r{/persistentvolumeclaims})
-      .to_return(body: open_test_file('persistent_volume_claim.json'),
-                 status: 200)
+      .to_return(body: open_test_file('persistent_volume_claim.json'), status: 200)
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     claim = client.get_persistent_volume_claim 'myclaim-1', 'default'
@@ -18,11 +16,15 @@ class TestPersistentVolumeClaim < MiniTest::Test
     assert_equal('3Gi', claim.spec.resources.requests.storage)
     assert_equal('pv0001', claim.spec.volumeName)
 
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1',
-                     times: 1)
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1/namespaces/default/persistentvolumeclaims/myclaim-1',
-                     times: 1)
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1',
+      times: 1
+    )
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1/namespaces/default/persistentvolumeclaims/myclaim-1',
+      times: 1
+    )
   end
 end

--- a/test/test_pod.rb
+++ b/test/test_pod.rb
@@ -4,11 +4,9 @@ require 'test_helper'
 class TestPod < MiniTest::Test
   def test_get_from_json_v1
     stub_request(:get, %r{/pods})
-      .to_return(body: open_test_file('pod.json'),
-                 status: 200)
+      .to_return(body: open_test_file('pod.json'), status: 200)
     stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new 'http://localhost:8080/api/', 'v1'
     pod = client.get_pod 'redis-master-pod', 'default'
@@ -17,11 +15,15 @@ class TestPod < MiniTest::Test
     assert_equal('redis-master3', pod.metadata.name)
     assert_equal('dockerfile/redis', pod.spec.containers[0]['image'])
 
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1',
-                     times: 1)
-    assert_requested(:get,
-                     'http://localhost:8080/api/v1/namespaces/default/pods/redis-master-pod',
-                     times: 1)
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1',
+      times: 1
+    )
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1/namespaces/default/pods/redis-master-pod',
+      times: 1
+    )
   end
 end

--- a/test/test_process_template.rb
+++ b/test/test_process_template.rb
@@ -19,10 +19,10 @@ class TestProcessTemplate < MiniTest::Test
     param = { name: 'NAME_PREFIX', value: 'test/' }
     template[:parameters] = [param]
 
-    req_body = "{\"metadata\":{\"name\":\"my-template\",\"namespace\":\"default\"},"\
-    "\"kind\":\"Template\",\"apiVersion\":\"v1\",\"objects\":[{\"metadata\":"\
-    "{\"name\":\"${NAME_PREFIX}my-service\"},\"kind\":\"Service\",\"apiVersion\":\"v1\"}],"\
-    "\"parameters\":[{\"name\":\"NAME_PREFIX\",\"value\":\"test/\"}]}"
+    req_body = '{"metadata":{"name":"my-template","namespace":"default"},' \
+      '"kind":"Template","apiVersion":"v1","objects":[{"metadata":' \
+      '{"name":"${NAME_PREFIX}my-service"},"kind":"Service","apiVersion":"v1"}],' \
+      '"parameters":[{"name":"NAME_PREFIX","value":"test/"}]}'
 
     expected_url = 'http://localhost:8080/api/v1/namespaces/default/processedtemplates'
     stub_request(:post, expected_url)

--- a/test/test_service.rb
+++ b/test/test_service.rb
@@ -11,9 +11,10 @@ class TestService < MiniTest::Test
     our_service.metadata.labels.name = 'guestbook'
 
     our_service.spec = {}
-    our_service.spec.ports = [{ 'port' => 3000,
-                                'targetPort' => 'http-server',
-                                'protocol' => 'TCP'
+    our_service.spec.ports = [{
+      'port' => 3000,
+      'targetPort' => 'http-server',
+      'protocol' => 'TCP'
     }]
 
     assert_equal('guestbook', our_service.metadata.labels.name)


### PR DESCRIPTION
@abonas 

fixing weird indents with old rubocop version did not work ... so bumping ...
found a few new things (frozen constants / weird indents / always use raise)

to me these all look more readable now ... let me know which ones you don't like and I'll change them