### PR TITLE
relax requirement on recursive-open-struct

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'rubocop', '= 0.46.0'
   spec.add_dependency 'rest-client'
-  spec.add_dependency 'recursive-open-struct', '= 1.0.0'
+  spec.add_dependency 'recursive-open-struct', '~> 1.0.0'
   spec.add_dependency 'http', '= 0.9.8'
 end


### PR DESCRIPTION
kubeclient requires recursive-open-struct to be 1.0.0. However, there
has been, on recursive-open-struct, 2 minor updates (1.0.2) which fix 2
issues:

https://github.com/aetherknight/recursive-open-struct/blob/master/CHANGELOG.md

Let's make the requirement be ~>1.0.0 so that we can take the minor
version fixes

Fixes#230

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>