### PR TITLE
Fix Minitest deprecation

### DIFF
--- a/test/test_service.rb
+++ b/test/test_service.rb
@@ -40,7 +40,7 @@ class TestService < MiniTest::Test
     assert_equal(created.spec.ports.size, our_service.spec.ports.size)
 
     # Check that original entity_config is not modified by kind/apiVersion patches:
-    assert_equal(our_service.kind, nil)
+    assert_nil(our_service.kind)
 
     assert_requested(:post, expected_url, times: 1) do |req|
       data = JSON.parse(req.body)


### PR DESCRIPTION
Fixes:

```
Use assert_nil if expecting nil from test/test_service.rb:43:in `test_construct_our_own_service'. This will fail in MT6.
```

cc @simon3z