### PR TITLE
Add requests timeouts option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,8 @@ Metrics/AbcSize:
 Metrics/LineLength:
   Max: 100
 Metrics/ParameterLists:
-  Max: 8
+  Max: 5
+  CountKeywordArgs: false
 Metrics/CyclomaticComplexity:
   Max: 8
 Metrics/ModuleLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,8 @@ Metrics/ModuleLength:
 Style/MethodCallWithArgsParentheses:
   Enabled: true
   IgnoredMethods: [require, raise, include, attr_reader, refute, assert]
-  Exclude: [Gemfile, Rakefile, kubeclient.gemspec]
+  Exclude: [Gemfile*, Rakefile, kubeclient.gemspec]
+Style/FileName:
+  Exclude: [Gemfile*]
 Security/MarshalLoad:
   Exclude: [test/**/*]

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,17 @@ rvm:
   - "2.1"
   - "2.2"
   - "2.3.0"
+gemfile:
+  - Gemfile
+  - Gemfile-rest-client-1.8.rb
 sudo: false
 cache: bundler
 script: bundle exec rake $TASK
 env:
  - TASK=test
  - TASK=rubocop
+matrix:
+  exclude:
+    # No point running rubocop with old rest-client
+    - gemfile: Gemfile-rest-client-1.8.rb
+      env: TASK=rubocop

--- a/Gemfile-rest-client-1.8.rb
+++ b/Gemfile-rest-client-1.8.rb
@@ -1,0 +1,11 @@
+# For travis to additionally test rest-client 1.x.
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in kubeclient.gemspec
+gemspec
+
+if dependencies.any? # needed for overriding with recent bundler (1.13 ?)
+  dependencies.delete('rest-client')
+  gem 'rest-client', '= 1.8.0'
+end


### PR DESCRIPTION
I have a use case for extending the http timeout (a big openshift cluster whose /oapi/v1/images takes >2min to compute before it starts sending data).
This PR adds new options to control the 2 timeouts rest-client exposes.

- I wasn't sure if the options should also affect watches, which currently have infinite timeout.  Watch data arrives at unpredictable intervals, I think just adding ability to timeout would not make a useful API, so decided to punt and wait for a use case.

- [x] Backward compatible: Works with rest-client 1.8 and 2.0 (extended travis matrix to test both).
  Default open timeout will depend on ruby version, which is exactly the previous behavior (added tests), users that want ruby-independent behavior can simply specify :open timeout.