### PR TITLE
Support ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - "2.1"
   - "2.2"
   - "2.3.0"
+  - "2.4.0"
 gemfile:
   - Gemfile
   - Gemfile-rest-client-1.8.rb

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-rg'
-  spec.add_development_dependency 'webmock', '~> 1.24.2'
+  spec.add_development_dependency 'webmock', '~> 2.3.1'
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'rubocop', '= 0.47.1'
   spec.add_dependency 'rest-client'

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -404,9 +404,11 @@ class KubeclientTest < MiniTest::Test
   end
 
   def test_api_basic_auth_success
-    stub_request(:get, 'http://username:password@localhost:8080/api/v1')
+    stub_request(:get, 'http://localhost:8080/api/v1')
+      .with(basic_auth: %w(username password))
       .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
-    stub_request(:get, 'http://username:password@localhost:8080/api/v1/pods')
+    stub_request(:get, 'http://localhost:8080/api/v1/pods')
+      .with(basic_auth: %w(username password))
       .to_return(body: open_test_file('pod_list.json'), status: 200)
 
     client = Kubeclient::Client.new(
@@ -420,15 +422,17 @@ class KubeclientTest < MiniTest::Test
     assert_equal(1, pods.size)
     assert_requested(
       :get,
-      'http://username:password@localhost:8080/api/v1/pods',
+      'http://localhost:8080/api/v1/pods',
       times: 1
     )
   end
 
   def test_api_basic_auth_back_comp_success
-    stub_request(:get, 'http://username:password@localhost:8080/api/v1')
+    stub_request(:get, 'http://localhost:8080/api/v1')
+      .with(basic_auth: %w(username password))
       .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
-    stub_request(:get, 'http://username:password@localhost:8080/api/v1/pods')
+    stub_request(:get, 'http://localhost:8080/api/v1/pods')
+      .with(basic_auth: %w(username password))
       .to_return(body: open_test_file('pod_list.json'), status: 200)
 
     client = Kubeclient::Client.new(
@@ -440,14 +444,15 @@ class KubeclientTest < MiniTest::Test
 
     assert_equal('Pod', pods.kind)
     assert_equal(1, pods.size)
-    assert_requested(:get, 'http://username:password@localhost:8080/api/v1/pods', times: 1)
+    assert_requested(:get, 'http://localhost:8080/api/v1/pods', times: 1)
   end
 
   def test_api_basic_auth_failure
     error_message = 'HTTP status code 401, 401 Unauthorized'
     response = OpenStruct.new(code: 401, message: '401 Unauthorized')
 
-    stub_request(:get, 'http://username:password@localhost:8080/api/v1')
+    stub_request(:get, 'http://localhost:8080/api/v1')
+      .with(basic_auth: %w(username password))
       .to_raise(Kubeclient::HttpError.new(401, error_message, response))
 
     client = Kubeclient::Client.new(
@@ -459,7 +464,7 @@ class KubeclientTest < MiniTest::Test
     assert_equal(401, exception.error_code)
     assert_equal(error_message, exception.message)
     assert_equal(response, exception.response)
-    assert_requested(:get, 'http://username:password@localhost:8080/api/v1', times: 1)
+    assert_requested(:get, 'http://localhost:8080/api/v1', times: 1)
   end
 
   def test_init_username_no_password


### PR DESCRIPTION
Bump to Webmock 2.3.1 which fixed `.close` stubbing for ruby 2.4.
(It's a dev dependency, shouldn't affect users of kubeclient.)

Update tests using user:pass@... urls — webmock 2.x treats basic auth as a header, not url part.
https://github.com/bblimke/webmock/blob/2.0/CHANGELOG.md#200

Fixes #242.  @jrafanie please review.