### PR TITLE
Add 'Host' header to fix the watcher

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -66,7 +66,7 @@ module Kubeclient
       @entities = {}
       @discovered = false
       @api_version = version
-      @headers = {}
+      @headers = { 'Host': URI(uri).host }
       @ssl_options = ssl_options
       @auth_options = auth_options
       @socket_options = socket_options


### PR DESCRIPTION
Hi, I have been debugging an issue with https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/issues/50

I've managed to replicate it with this:

```
require 'kubeclient'

ssl_options = { verify_ssl: OpenSSL::SSL::VERIFY_NONE }
auth_options = {
  bearer_token_file: 'token'
}
client = Kubeclient::Client.new(
  'https://kubernetes/api/', 'v1', auth_options: auth_options, ssl_options: ssl_options
)

watcher = client.watch_pods
watcher.each do |notice|
  puts notice
end

```

I'm not sure if this is the best way to resolve this, but it works. 

Here is the error message I was getting before:
```
400 Bad Request: missing required Host header
.gem/ruby/2.4.1/gems/kubeclient-2.4.0/lib/kubeclient/watch_stream.rb:27:in `each': Bad Request (Kubeclient::HttpError)
```