### PR TITLE
Process JSON Body of ListObjects using streaming json parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,22 @@ pods = client.get_pods as: :raw
 node = client.get_node "127.0.0.1", as: :raw
 ```
 
+### Yielding lists entity-by-entity
+ By passing a block to any `get_*` method that returns a list (e.g.: `get_pods`, `get_nodes`, `get_namespaces`), entities will be yielded one-by-one to the passed block rather than returned as an array. This permits handling entities in large lists asynchronously while parsing takes place.
+   
+ For example:
+ ```ruby
+ client.get_services do |service, resource_version|
+   puts service
+   puts resource_version
+ end
+    
+ #<Kubeclient::Service metadata={:name=>"kubernetes", :namespace=>"default", :selfLink=>"/api/v1/services/kubernetes?namespace=default", :uid=>"016e9dcd-ce39-11e4-ac24-3c970e4a436a", :resourceVersion=>"6", :creationTimestamp=>"2015-03-19T15:08:16+02:00", :labels=>{:component=>"apiserver", :provider=>"kubernetes"}}, spec={:port=>443, :protocol=>"TCP", :selector=>nil, :clusterIP=>"10.0.0.2", :containerPort=>0, :sessionAffinity=>"None"}, status={}>
+ 59
+ #<Kubeclient::Service metadata={:name=>"kubernetes-ro", :namespace=>"default", :selfLink=>"/api/v1/services/kubernetes-ro?namespace=default", :uid=>"015b78bf-ce39-11e4-ac24-3c970e4a436a", :resourceVersion=>"5", :creationTimestamp=>"2015-03-19T15:08:15+02:00", :labels=>{:component=>"apiserver", :provider=>"kubernetes"}}, spec={:port=>80, :protocol=>"TCP", :selector=>nil, :clusterIP=>"10.0.0.1", :containerPort=>0, :sessionAffinity=>"None"}, status={}>
+ 59
+ ```
+
 #### Delete an entity (by name)
 
 For example: `delete_pod "pod name"` , `delete_replication_controller "rc name"`, `delete_node "node name"`, `delete_secret "secret name"`

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'recursive-open-struct', '~> 1.0.4'
   spec.add_dependency 'http', '~> 2.2.2'
+  spec.add_dependency 'json-streamer', '~> 2.0.0'
 end


### PR DESCRIPTION
This PR changes `Kubeclient::get_entities` as follows:

1. Use `RestClient::Request.execute` in place of `RestClient::Resource.get` to read HTTP Response body in chunks.
2. Use [`Json::Streamer`](https://github.com/thisismydesign/json-streamer) to parse chunks as a JSON stream.
3. If the caller passes a block, we yield entities as they are parsed from the stream of json. Otherwise we collect entities and return them as a `Kubeclient::Common::EntityList` as before.