### PR TITLE
Fixes warnings in test output (and a potential bug)

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -127,9 +127,9 @@ module Kubeclient
     def self.parse_definition(kind, name)
       # "name": "componentstatuses", networkpolicies, endpoints
       # "kind": "ComponentStatus" NetworkPolicy, Endpoints
-      # maintain pre group api compatibility for endpoints.
+      # maintain pre group api compatibility for endpoints and securitycontextconstraints.
       # See: https://github.com/kubernetes/kubernetes/issues/8115
-      kind = 'Endpoint' if kind == 'Endpoints'
+      kind = kind[0..-2] if %w[Endpoints SecurityContextConstraints].include?(kind)
 
       prefix = kind[0..kind.rindex(/[A-Z]/)] # NetworkP
       m = name.match(/^#{prefix.downcase}(.*)$/)

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -73,7 +73,7 @@ module Kubeclient
       # Allow passing partial timeouts hash, without unspecified
       # @timeouts[:foo] == nil resulting in infinite timeout.
       @timeouts = DEFAULT_TIMEOUTS.merge(timeouts)
-      @http_proxy_uri = http_proxy_uri.to_s if http_proxy_uri
+      @http_proxy_uri = http_proxy_uri ? http_proxy_uri.to_s : nil
 
       if auth_options[:bearer_token]
         bearer_token(@auth_options[:bearer_token])


### PR DESCRIPTION
These warnings have actually been in place for a while, but because of the recent pull request to [update dependencies](https://github.com/abonas/kubeclient/pull/253), rake was updated from version 10 to version 12, it [included this PR](https://github.com/ruby/rake/pull/97) to run with `-w`, which will print out warnings when the test suite is executed.


Warnings Fixed
--------------

* `instance variable @http_proxy_uri not initialized`
  - Caused when a `http_proxy_uri` arg is not passed into the `Kubernetes::Client.new`, and any method using `@http_proxy_uri` is called (which is most useful methods on the client.
* `warning: method redefined; discarding old get_security_context_constraints`
  - This was a bug in the `Kubeclient::Common::MissingKindCompatability` class, which the `'securitycontextconstraints' => 'SecurityContextConstraint',` map was setup with the plural version of the "kind" (`SecurityContextConstraints`), instead of the Singular.  This caused `get_security_context_constraints` to be defined for both the `get_entity` and the `get_entities` actions, but only the `get_entity` action would be available.

The second one is probably a bug that has existed since https://github.com/abonas/kubeclient/pull/214, so the `v1.0.0` release and newer (I think) of `kubeclient` have been unable to access the `securitycontextconstraints` index actions on older versions of the kubernetes API.  Using `Kubeclient::Client#get_security_constant_contraints` would actually be running the `get` action for a single record.

The above needs to be confirmed, but I relatively sure this would be the case (unfortunately I don't really have a live and legacy kubernetes environment where I could test this).