### PR TITLE
Adds raw option for client get requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,14 @@ service = client.get_service "guestbook", 'development'
 Note - Kubernetes doesn't work with the uid, but rather with the 'name' property.
 Querying with uid causes 404.
 
+#### Getting raw responses
+By passing `as: :raw`, the response from the client is given as a string, which is the raw JSON body from openshift:
+
+```ruby
+pods = client.get_pods as: :raw
+node = client.get_node "127.0.0.1", as: :raw
+```
+
 #### Delete an entity (by name)
 
 For example: `delete_pod "pod name"` , `delete_replication_controller "rc name"`, `delete_node "node name"`, `delete_secret "secret name"`

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -190,8 +190,8 @@ module Kubeclient
         end
 
         # get a single entity of a specific type by name
-        define_singleton_method("get_#{entity.method_names[0]}") do |name, namespace = nil|
-          get_entity(klass, entity.resource_name, name, namespace)
+        define_singleton_method("get_#{entity.method_names[0]}") do |name, ns = nil, opts = {}|
+          get_entity(klass, entity.resource_name, name, ns, opts)
         end
 
         define_singleton_method("delete_#{entity.method_names[0]}") do |name, namespace = nil|
@@ -239,12 +239,12 @@ module Kubeclient
       end
     end
 
-    # Accepts the following string options:
-    #   :namespace - the namespace of the entity.
-    #   :name - the name of the entity to watch.
-    #   :label_selector - a selector to restrict the list of returned objects by their labels.
-    #   :field_selector - a selector to restrict the list of returned objects by their fields.
-    #   :resource_version - shows changes that occur after that particular version of a resource.
+    # Accepts the following options:
+    #   :namespace (string) - the namespace of the entity.
+    #   :name (string) - the name of the entity to watch.
+    #   :label_selector (string) - a selector to restrict the list of returned objects by labels.
+    #   :field_selector (string) - a selector to restrict the list of returned objects by fields.
+    #   :resource_version (string) - shows changes that occur after passed version of a resource.
     def watch_entities(resource_name, options = {})
       ns = build_namespace_prefix(options[:namespace])
 
@@ -259,10 +259,14 @@ module Kubeclient
       Kubeclient::Common::WatchStream.new(uri, http_options(uri))
     end
 
-    # Accepts the following string options:
-    #   :namespace - the namespace of the entity.
-    #   :label_selector - a selector to restrict the list of returned objects by their labels.
-    #   :field_selector - a selector to restrict the list of returned objects by their fields.
+    # Accepts the following options:
+    #   :namespace (string) - the namespace of the entity.
+    #   :label_selector (string) - a selector to restrict the list of returned objects by labels.
+    #   :field_selector (string) - a selector to restrict the list of returned objects by fields.
+    #   :as (symbol) - if :raw, return the raw response body (as a string)
+    #
+    #   Default response type will return a collection RecursiveOpenStruct
+    #   (:ros) objects, unless `:as` is passed with `:raw`.
     def get_entities(entity_type, klass, resource_name, options = {})
       params = {}
       SEARCH_ARGUMENTS.each { |k, v| params[k] = options[v] if options[v] }
@@ -272,6 +276,7 @@ module Kubeclient
         rest_client[ns_prefix + resource_name]
           .get({ 'params' => params }.merge(@headers))
       end
+      return response.body if options[:as] == :raw
 
       result = JSON.parse(response)
 
@@ -286,12 +291,19 @@ module Kubeclient
       Kubeclient::Common::EntityList.new(entity_type, resource_version, collection)
     end
 
-    def get_entity(klass, resource_name, name, namespace = nil)
+    # Accepts the following options:
+    #   :as (symbol) - if :raw, return the raw response body (as a string)
+    #
+    #   Default response type will return an entity as a  RecursiveOpenStruct
+    #   (:ros) object, unless `:as` is passed with `:raw`.
+    def get_entity(klass, resource_name, name, namespace = nil, options = {})
       ns_prefix = build_namespace_prefix(namespace)
       response = handle_exception do
         rest_client[ns_prefix + resource_name + "/#{name}"]
           .get(@headers)
       end
+      return response.body if options[:as] == :raw
+
       result = JSON.parse(response)
       new_entity(result, klass)
     end
@@ -350,14 +362,14 @@ module Kubeclient
       klass.new(hash)
     end
 
-    def all_entities
+    def all_entities(options = {})
       discover unless @discovered
       @entities.values.each_with_object({}) do |entity, result_hash|
         # method call for get each entities
         # build hash of entity name to array of the entities
         method_name = "get_#{entity.method_names[1]}"
         begin
-          result_hash[entity.method_names[0]] = send(method_name)
+          result_hash[entity.method_names[0]] = send(method_name, options)
         rescue Kubeclient::HttpError
           next # do not fail due to resources not supporting get
         end

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -193,6 +193,22 @@ class KubeclientTest < MiniTest::Test
     assert_equal(404, exception.error_code)
   end
 
+  def test_nonjson_exception_raw
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
+    stub_request(:get, %r{/servic})
+      .to_return(body: open_test_file('service_illegal_json_404.json'), status: 404)
+
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+
+    exception = assert_raises(Kubeclient::ResourceNotFoundError) do
+      client.get_services(as: :raw)
+    end
+
+    assert(exception.message.include?('Not Found'))
+    assert_equal(404, exception.error_code)
+  end
+
   def test_entity_list
     stub_request(:get, %r{/api/v1$})
       .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
@@ -210,6 +226,34 @@ class KubeclientTest < MiniTest::Test
     assert_instance_of(Kubeclient::Service, services[1])
 
     assert_requested(:get, 'http://localhost:8080/api/v1/services', times: 1)
+  end
+
+  def test_entity_list_raw
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
+    stub_request(:get, %r{/services})
+      .to_return(body: open_test_file('entity_list.json'), status: 200)
+
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+    response = client.get_services(as: :raw)
+
+    refute_empty(response)
+    assert_equal(open_test_file('entity_list.json').read, response)
+
+    assert_requested(:get, 'http://localhost:8080/api/v1/services', times: 1)
+  end
+
+  def test_entity_list_raw_failure
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
+    stub_request(:get, %r{/services})
+      .to_return(body: open_test_file('entity_list.json'), status: 500)
+
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+
+    exception = assert_raises(Kubeclient::HttpError) { client.get_services(as: :raw) }
+    assert_equal('500 Internal Server Error', exception.message)
+    assert_equal(500, exception.error_code)
   end
 
   def test_entities_with_label_selector
@@ -341,6 +385,74 @@ class KubeclientTest < MiniTest::Test
     assert_instance_of(Kubeclient::ServiceAccount, result['service_account'][0])
   end
 
+  def test_get_all_raw
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
+
+    stub_request(:get, %r{/bindings})
+      .to_return(body: open_test_file('bindings_list.json'), status: 404)
+
+    stub_request(:get, %r{/configmaps})
+      .to_return(body: open_test_file('config_map_list.json'), status: 200)
+
+    stub_request(:get, %r{/podtemplates})
+      .to_return(body: open_test_file('pod_template_list.json'), status: 200)
+
+    stub_request(:get, %r{/services})
+      .to_return(body: open_test_file('service_list.json'), status: 200)
+
+    stub_request(:get, %r{/pods})
+      .to_return(body: open_test_file('pod_list.json'), status: 200)
+
+    stub_request(:get, %r{/nodes})
+      .to_return(body: open_test_file('node_list.json'), status: 200)
+
+    stub_request(:get, %r{/replicationcontrollers})
+      .to_return(body: open_test_file('replication_controller_list.json'), status: 200)
+
+    stub_request(:get, %r{/events})
+      .to_return(body: open_test_file('event_list.json'), status: 200)
+
+    stub_request(:get, %r{/endpoints})
+      .to_return(body: open_test_file('endpoint_list.json'), status: 200)
+
+    stub_request(:get, %r{/namespaces})
+      .to_return(body: open_test_file('namespace_list.json'), status: 200)
+
+    stub_request(:get, %r{/secrets})
+      .to_return(body: open_test_file('secret_list.json'), status: 200)
+
+    stub_request(:get, %r{/resourcequotas})
+      .to_return(body: open_test_file('resource_quota_list.json'), status: 200)
+
+    stub_request(:get, %r{/limitranges})
+      .to_return(body: open_test_file('limit_range_list.json'), status: 200)
+
+    stub_request(:get, %r{/persistentvolumes})
+      .to_return(body: open_test_file('persistent_volume_list.json'), status: 200)
+
+    stub_request(:get, %r{/persistentvolumeclaims})
+      .to_return(body: open_test_file('persistent_volume_claim_list.json'), status: 200)
+
+    stub_request(:get, %r{/componentstatuses})
+      .to_return(body: open_test_file('component_status_list.json'), status: 200)
+
+    stub_request(:get, %r{/serviceaccounts})
+      .to_return(body: open_test_file('service_account_list.json'), status: 200)
+
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+    result = client.all_entities(as: :raw)
+    assert_equal(16, result.keys.size)
+
+    %w[
+      component_status config_map endpoint event limit_range namespace node
+      persistent_volume persistent_volume_claim pod replication_controller
+      resource_quota secret service service_account
+    ].each do |entity|
+      assert_equal(open_test_file("#{entity}_list.json").read, result[entity])
+    end
+  end
+
   def test_api_bearer_token_with_params_success
     stub_request(:get, 'http://localhost:8080/api/v1/pods?labelSelector=name=redis-master')
       .with(headers: { Authorization: 'Bearer valid_token' })
@@ -398,6 +510,27 @@ class KubeclientTest < MiniTest::Test
     )
 
     exception = assert_raises(Kubeclient::HttpError) { client.get_pods }
+    assert_equal(403, exception.error_code)
+    assert_equal(error_message, exception.message)
+    assert_equal(response, exception.response)
+  end
+
+  def test_api_bearer_token_failure_raw
+    error_message =
+      '"/api/v1" is forbidden because ' \
+      'system:anonymous cannot list on pods in'
+    response = OpenStruct.new(code: 401, message: error_message)
+
+    stub_request(:get, 'http://localhost:8080/api/v1')
+      .with(headers: { Authorization: 'Bearer invalid_token' })
+      .to_raise(Kubeclient::HttpError.new(403, error_message, response))
+
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/',
+      auth_options: { bearer_token: 'invalid_token' }
+    )
+
+    exception = assert_raises(Kubeclient::HttpError) { client.get_pods(as: :raw) }
     assert_equal(403, exception.error_code)
     assert_equal(error_message, exception.message)
     assert_equal(response, exception.response)
@@ -464,6 +597,27 @@ class KubeclientTest < MiniTest::Test
     assert_equal(401, exception.error_code)
     assert_equal(error_message, exception.message)
     assert_equal(response, exception.response)
+    assert_requested(:get, 'http://localhost:8080/api/v1', times: 1)
+  end
+
+  def test_api_basic_auth_failure_raw
+    error_message = 'HTTP status code 401, 401 Unauthorized'
+    response = OpenStruct.new(code: 401, message: '401 Unauthorized')
+
+    stub_request(:get, 'http://localhost:8080/api/v1')
+      .with(basic_auth: %w[username password])
+      .to_raise(Kubeclient::HttpError.new(401, error_message, response))
+
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/',
+      auth_options: { username: 'username', password: 'password' }
+    )
+
+    exception = assert_raises(Kubeclient::HttpError) { client.get_pods(as: :raw) }
+    assert_equal(401, exception.error_code)
+    assert_equal(error_message, exception.message)
+    assert_equal(response, exception.response)
+
     assert_requested(:get, 'http://localhost:8080/api/v1', times: 1)
   end
 

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -30,4 +30,43 @@ class TestNode < MiniTest::Test
       times: 1
     )
   end
+
+  def test_get_from_json_v1_raw
+    stub_request(:get, %r{/nodes})
+      .to_return(body: open_test_file('node.json'), status: 200)
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
+
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+    response = client.get_node('127.0.0.1', nil, as: :raw)
+
+    assert_equal(open_test_file('node.json').read, response)
+
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1',
+      times: 1
+    )
+    assert_requested(
+      :get,
+      'http://localhost:8080/api/v1/nodes/127.0.0.1',
+      times: 1
+    )
+  end
+
+  def test_get_from_json_v1_raw_error
+    stub_request(:get, %r{/nodes})
+      .to_return(body: open_test_file('node.json'), status: 200)
+    stub_request(:get, %r{/api/v1$})
+      .to_return(body: open_test_file('core_api_resource_list.json'), status: 500)
+
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+
+    exception = assert_raises(Kubeclient::HttpError) do
+      client.get_node('127.0.0.1', nil, as: :raw)
+    end
+
+    assert_instance_of(Kubeclient::HttpError, exception)
+    assert_equal('500 Internal Server Error', exception.message)
+  end
 end


### PR DESCRIPTION
Prevents parsing of response body into `Kubeclient` objects.  In large kubernetes cluster environments where it would saving off the raw json for later use can useful for memory tight scenarios.

Usage:
------

```ruby
client = Kubeclient::Client.new(KUBECIENT_URL, 'v1')

client.get_endpoints                                        # normal
client.get_endpoints :raw => true                           # raw

client.get_endpoints "default_endpoint"                     # normal
client.get_endpoints "default_endpoint", nil, :raw => true  # raw
```