### PR TITLE
Tell Rubocop to target Ruby 2.2 (oldest we support)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   DisplayCopNames: true
+  TargetRubyVersion: 2.2 # Oldest version kubeclient supports
 MethodLength:
   Enabled: false
 ClassLength:


### PR DESCRIPTION
When not configured, Rubocop normally defaults to 2.1 (oldest version Rubocop currently deals with), but if you have a `.ruby-version` file, it uses that.

Note that I'm talking about which **ruby syntax** Rubocop expects/suggests, NOT which Ruby it's **running under**.

## Travis
This PR makes rubocop target syntax 2.2 instead of 2.1.  Slightly more correct, I'm not aware of concrete effects.
- It's still running **under* each 2.2, 2.3, 2.4.  The results should be always same — if not that's a bug in Rubocop — so we could disable all but one, but that's out of scope here.

## Locally
This PR makes rubocop target syntax 2.2 and ignores `.ruby-version` file.
It was confusing that creating local `.ruby-version` for rbenv/rvm/etc. in kubeclient dir to test it under specific ruby, also affected which syntax Rubocop targets (and extra confusing why it doesn't vary between ruby versions on Travis — because it depends on file not on what it runs under).

Specifically, for 2.3+ it demands `frozen_string_literal` comment in all files, which we don't want (as long as we support 2.2).