### PR TITLE
Recurse over arrays for watch notices

### DIFF
--- a/lib/kubeclient/watch_notice.rb
+++ b/lib/kubeclient/watch_notice.rb
@@ -1,7 +1,12 @@
 require 'recursive_open_struct'
 module Kubeclient
   module Common
+    # Represents an individual notice received from a Kubernetes watch
     class WatchNotice < RecursiveOpenStruct
+      def initialize(hash = nil, args = {})
+        args[:recurse_over_arrays] = true
+        super(hash, args)
+      end
     end
   end
 end

--- a/test/json/node_notice.json
+++ b/test/json/node_notice.json
@@ -1,0 +1,160 @@
+{
+  "type": "ADDED",
+  "object": {
+    "apiVersion": "v1",
+    "kind": "Node",
+    "metadata": {
+      "annotations": {
+        "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+      },
+      "creationTimestamp": "2017-12-11T12:00:13Z",
+      "labels": {
+        "beta.kubernetes.io/arch": "amd64",
+        "beta.kubernetes.io/os": "linux",
+        "kubernetes.io/hostname": "openshift.local",
+        "openshift-infra": "apiserver"
+      },
+      "name": "openshift.local",
+      "resourceVersion": "367410",
+      "selfLink": "/api/v1/nodes/openshift.local",
+      "uid": "d88c7af6-de6a-11e7-8725-52540080f1d2"
+    },
+    "spec": {
+      "externalID": "openshift.local"
+    },
+    "status": {
+      "addresses": [
+        {
+          "address": "192.168.122.40",
+          "type": "InternalIP"
+        },
+        {
+          "address": "openshift.local",
+          "type": "Hostname"
+        }
+      ],
+      "allocatable": {
+        "cpu": "2",
+        "memory": "8072896Ki",
+        "pods": "20"
+      },
+      "capacity": {
+        "cpu": "2",
+        "memory": "8175296Ki",
+        "pods": "20"
+      },
+      "conditions": [
+        {
+          "lastHeartbeatTime": "2017-12-15T00:36:13Z",
+          "lastTransitionTime": "2017-12-11T12:00:13Z",
+          "message": "kubelet has sufficient disk space available",
+          "reason": "KubeletHasSufficientDisk",
+          "status": "False",
+          "type": "OutOfDisk"
+        },
+        {
+          "lastHeartbeatTime": "2017-12-15T00:36:13Z",
+          "lastTransitionTime": "2017-12-11T12:00:13Z",
+          "message": "kubelet has sufficient memory available",
+          "reason": "KubeletHasSufficientMemory",
+          "status": "False",
+          "type": "MemoryPressure"
+        },
+        {
+          "lastHeartbeatTime": "2017-12-15T00:36:13Z",
+          "lastTransitionTime": "2017-12-11T12:00:13Z",
+          "message": "kubelet has no disk pressure",
+          "reason": "KubeletHasNoDiskPressure",
+          "status": "False",
+          "type": "DiskPressure"
+        },
+        {
+          "lastHeartbeatTime": "2017-12-15T00:36:13Z",
+          "lastTransitionTime": "2017-12-14T15:43:39Z",
+          "message": "kubelet is posting ready status",
+          "reason": "KubeletReady",
+          "status": "True",
+          "type": "Ready"
+        }
+      ],
+      "daemonEndpoints": {
+        "kubeletEndpoint": {
+          "Port": 10250
+        }
+      },
+      "images": [
+        {
+          "names": [
+            "docker.io/openshift/origin@sha256:908c6c9ccf0e0feefe2658899656c6e73d2854777fa340738fb903f0a40c328d",
+            "docker.io/openshift/origin:latest"
+          ],
+          "sizeBytes": 1222636603
+        },
+        {
+          "names": [
+            "docker.io/openshift/origin-deployer@sha256:3d324bce1870047edc418041cefdec88e0a5bbb5b3b9f6fd35b43f14919a656c",
+            "docker.io/openshift/origin-deployer:v3.7.0"
+          ],
+          "sizeBytes": 1098951248
+        },
+        {
+          "names": [
+            "docker.io/cockpit/kubernetes@sha256:a8e58cd5e6f5a4d12d1e2dfd339686b74f3c22586952ca7aa184dc254ab49714",
+            "docker.io/cockpit/kubernetes:latest"
+          ],
+          "sizeBytes": 375926556
+        },
+        {
+          "names": [
+            "docker.io/cockpit/kubernetes@sha256:0745b3823efc57e03a5ef378614dfcb6c2b1e3964220bbf908fb3046a91cef70"
+          ],
+          "sizeBytes": 350062743
+        },
+        {
+          "names": [
+            "docker.io/openshift/origin-service-catalog@sha256:ef851e06276af96838a93320d0e4be51cc8de6e5afb2fb0efd4e56cec114b937"
+          ],
+          "sizeBytes": 284732029
+        },
+        {
+          "names": [
+            "docker.io/openshift/origin-service-catalog@sha256:8addfd742d92d8da819b091d6bda40edc45e88d1446ffd1ad658b6d21b3c36fd"
+          ],
+          "sizeBytes": 284731998
+        },
+        {
+          "names": [
+            "docker.io/openshift/origin-service-catalog@sha256:b3a737cc346b3cae85ef2f5d020b607781a1cac38fe70678cb78fee2c2a3bf8a"
+          ],
+          "sizeBytes": 284731943
+        },
+        {
+          "names": [
+            "docker.io/openshift/origin-service-catalog@sha256:957934537721da33362693d4f1590dc79dc5da7438799bf14d645165768e53ef",
+            "docker.io/openshift/origin-service-catalog:latest"
+          ],
+          "sizeBytes": 283929631
+        },
+        {
+          "names": [
+            "docker.io/openshift/origin-pod@sha256:2c257d83a01607b229ef5e3dca09f52c3a2a2788c09dc33f0444ec4e572a9e1d",
+            "docker.io/openshift/origin-pod:v3.7.0"
+          ],
+          "sizeBytes": 218423400
+        }
+      ],
+      "nodeInfo": {
+        "architecture": "amd64",
+        "bootID": "75be791d-88a2-4f56-a588-c071a80bf7cf",
+        "containerRuntimeVersion": "docker://1.12.6",
+        "kernelVersion": "3.10.0-693.11.1.el7.x86_64",
+        "kubeProxyVersion": "v1.7.6+a08f5eeb62",
+        "kubeletVersion": "v1.7.6+a08f5eeb62",
+        "machineID": "adf09ffc2de2624aa5ed335727c7400d",
+        "operatingSystem": "linux",
+        "osImage": "CentOS Linux 7 (Core)",
+        "systemUUID": "FC9FF0AD-E22D-4A62-A5ED-335727C7400D"
+      }
+    }
+  }
+}

--- a/test/test_watch_notice.rb
+++ b/test/test_watch_notice.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class TestWatchNotice < MiniTest::Test
+  #
+  # Checks that elements of arrays are converted to instances of `RecursiveOpenStruct`, and that the
+  # items can be accessed using the dot notation.
+  #
+  def test_recurse_over_arrays
+    json = JSON.parse(open_test_file('node_notice.json').read)
+    notice = Kubeclient::Common::WatchNotice.new(json)
+    assert_kind_of(Array, notice.object.status.addresses)
+    notice.object.status.addresses.each do |address|
+      assert_kind_of(RecursiveOpenStruct, address)
+    end
+    assert_equal('InternalIP', notice.object.status.addresses[0].type)
+    assert_equal('192.168.122.40', notice.object.status.addresses[0].address)
+    assert_equal('Hostname', notice.object.status.addresses[1].type)
+    assert_equal('openshift.local', notice.object.status.addresses[1].address)
+  end
+
+  #
+  # Checks that even when arrays are converted to instances of `RecursiveOpenStruct` the items can
+  # be accessed using the hash notation.
+  #
+  def test_access_array_items_as_hash
+    json = JSON.parse(open_test_file('node_notice.json').read)
+    notice = Kubeclient::Common::WatchNotice.new(json)
+    assert_kind_of(Array, notice.object.status.addresses)
+    notice.object.status.addresses.each do |address|
+      assert_kind_of(RecursiveOpenStruct, address)
+    end
+    assert_equal('InternalIP', notice.object.status.addresses[0]['type'])
+    assert_equal('192.168.122.40', notice.object.status.addresses[0]['address'])
+    assert_equal('Hostname', notice.object.status.addresses[1]['type'])
+    assert_equal('openshift.local', notice.object.status.addresses[1]['address'])
+  end
+end


### PR DESCRIPTION
Currently the elements of arrays inside watch notices aren't converted
to intances of `RecursiveOpenStruct`, they are converted to instances of `Hash`
instead. This mean that accessing certain fields works differently for
objects retrieved directly than for objects received in a notice. For
example, to extract the internal IP address of a node retrieved directly
the code is like this:

```ruby
ip = node.status.addresses.detect { |x| x.type == 'InternalIP' }.address
```

But for a notice it is like this:

```ruby
ip = node.status.addresses.detect { |x| x['type'] == 'InternalIP' }['address']
```

This complicates code that needs to treat objects in the same way,
regardless of how they have been retrieved.

To avoid that this patch changes the `WatchNotice` class so that the
constructor adds the _RecursiveOpenStruct_ `:recurse_over_arrays` option.