### PR TITLE
Catch EBADF when watch_stream fails

### DIFF
--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -27,7 +27,7 @@ module Kubeclient
             yield(@format == :json ? WatchNotice.new(JSON.parse(line)) : line.chomp)
           end
         end
-      rescue IOError
+      rescue IOError, Errno::EBADF
         raise unless @finished
       end
 


### PR DESCRIPTION
Solves https://bugzilla.redhat.com/show_bug.cgi?id=1507528
TBH I think we can catch any exception there and not `IOError, EBADF` specifically.

Explanation:
until `finish` is called, the code is looping in `response.body.each do |chunk|`.
finish closes `@http_client` while the other thread is reading from it so there could be any exception there depending where exactly the other thread is.


This isnt a great solution but the bug is just an error in the log and isnt an actual usability issue 
@cben @agrare @moolitayer Please review