### PR TITLE
[v2.x ONLY] Ease dependency on http gem

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '= 0.30.0'
   spec.add_dependency 'rest-client'
   spec.add_dependency 'recursive-open-struct', '= 1.0.0'
-  spec.add_dependency 'http', '= 0.9.8'
+  spec.add_dependency 'http', '< 3', '>= 0.98'
 end


### PR DESCRIPTION
We do not want to bump this dependency on 2.x however we do do want to allow users to use a newer version.
