### PR TITLE
Fix README comment on Kubeclient::HttpError

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,9 +476,9 @@ client.process_template template
 
 ## Upgrading
 
-#### past version 2.0
+#### past version 2.6
 
-Replace `KubeException` with `Kubeclient::HttpException`
+The gem raises Kubeclient::HttpError or subclasses now. Catching KubeException still works but is deprecated.
 
 #### past version 1.2.0
 Replace Specific Entity class references:


### PR DESCRIPTION
https://github.com/abonas/kubeclient/pull/195/files#diff-04c6e90faac2675aa89e2176d2eec7d8R425 introduced the new exception and @cben noticed the README note matches a name that was changed during review.

This change is not currently(2018-01-25) included in a release and it is planned for upcoming `v2.6.0` and `v3.0.0`