### PR TITLE
update delete and patch should return ROS

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ For example: `delete_pod "pod name"` , `delete_replication_controller "rc name"`
 Input parameter - name (string) specifying service name, pod name, replication controller name.
 
 ```ruby
-client.delete_service("redis-service")
+deleted = client.delete_service("redis-service")
 ```
 
 If you want to cascade delete, for example a deployment, you can use the `delete_options` parameter.
@@ -362,7 +362,7 @@ Input parameter - object of type `Pod`, `Service`, `ReplicationController` etc.
 The below example is for v1
 
 ```ruby
-client.update_service(service1)
+updated = client.update_service(service1)
 ```
 
 #### Patch an entity (by name)
@@ -375,7 +375,7 @@ The PATCH request should include the namespace name, except for nodes and namesp
 The below example is for v1
 
 ```ruby
-client.patch_pod("docker-registry", {metadata: {annotations: {key: 'value'}}}, "default")
+patched = client.patch_pod("docker-registry", {metadata: {annotations: {key: 'value'}}}, "default")
 ```
 
 #### Get all entities of all types : all_entities
@@ -487,6 +487,8 @@ Checking the type of a resource can be done using:
 > pod.kind
 => "Pod"
 ```
+
+update_* delete_* and patch_* now return a RecursiveOpenStruct like the get_* methods
 
 #### past version 2.6
 

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -286,17 +286,15 @@ module Kubeclient
         rest_client[ns_prefix + resource_name + "/#{name}"]
           .get(@headers)
       end
-      return response.body if options[:as] == :raw
-
-      result = JSON.parse(response)
-      Kubeclient::Resource.new(result)
+      format_response(options[:as], response)
     end
 
+    # delete_options are passed as a JSON payload in the delete request
     def delete_entity(resource_name, name, namespace = nil, delete_options: {})
       delete_options_hash = delete_options.to_hash
       ns_prefix = build_namespace_prefix(namespace)
       payload = delete_options_hash.to_json unless delete_options_hash.empty?
-      _response = handle_exception do
+      response = handle_exception do
         rs = rest_client[ns_prefix + resource_name + "/#{name}"]
         RestClient::Request.execute(
           rs.options.merge(
@@ -307,6 +305,7 @@ module Kubeclient
           )
         )
       end
+      format_response(:ros, response)
     end
 
     def create_entity(entity_type, resource_name, entity_config)
@@ -327,28 +326,29 @@ module Kubeclient
         rest_client[ns_prefix + resource_name]
           .post(hash.to_json, { 'Content-Type' => 'application/json' }.merge(@headers))
       end
-      result = JSON.parse(response)
-      Kubeclient::Resource.new(result)
+      format_response(:ros, response)
     end
 
     def update_entity(resource_name, entity_config)
       name      = entity_config[:metadata][:name]
       ns_prefix = build_namespace_prefix(entity_config[:metadata][:namespace])
-      handle_exception do
+      response = handle_exception do
         rest_client[ns_prefix + resource_name + "/#{name}"]
           .put(entity_config.to_h.to_json, { 'Content-Type' => 'application/json' }.merge(@headers))
       end
+      format_response(:ros, response)
     end
 
     def patch_entity(resource_name, name, patch, namespace = nil)
       ns_prefix = build_namespace_prefix(namespace)
-      handle_exception do
+      response = handle_exception do
         rest_client[ns_prefix + resource_name + "/#{name}"]
           .patch(
             patch.to_json,
             { 'Content-Type' => 'application/strategic-merge-patch+json' }.merge(@headers)
           )
       end
+      format_response(:ros, response)
     end
 
     def all_entities(options = {})
@@ -431,6 +431,13 @@ module Kubeclient
     end
 
     private
+
+    def format_response(as, response)
+      return response.body if as == :raw
+
+      result = JSON.parse(response)
+      Kubeclient::Resource.new(result)
+    end
 
     def load_entities
       @entities = {}

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -228,8 +228,9 @@ module Kubeclient
     #   :label_selector (string) - a selector to restrict the list of returned objects by labels.
     #   :field_selector (string) - a selector to restrict the list of returned objects by fields.
     #   :resource_version (string) - shows changes that occur after passed version of a resource.
-    #   Default response type will return an entity as a  RecursiveOpenStruct
-    #   (:ros) object, unless `:as` is passed with `:raw`.
+    #   :as (:raw|:ros) - defaults to :ros
+    #     :raw - return the raw response body as a string
+    #     :ros - return a collection of RecursiveOpenStruct objects
     def watch_entities(resource_name, options = {})
       ns = build_namespace_prefix(options[:namespace])
 
@@ -248,10 +249,9 @@ module Kubeclient
     #   :namespace (string) - the namespace of the entity.
     #   :label_selector (string) - a selector to restrict the list of returned objects by labels.
     #   :field_selector (string) - a selector to restrict the list of returned objects by fields.
-    #   :as (symbol) - if :raw, return the raw response body (as a string)
-    #
-    #   Default response type will return a collection RecursiveOpenStruct
-    #   (:ros) objects, unless `:as` is passed with `:raw`.
+    #   :as (:raw|:ros) - defaults to :ros
+    #     :raw - return the raw response body as a string
+    #     :ros - return a collection of RecursiveOpenStruct objects
     def get_entities(entity_type, resource_name, options = {})
       params = {}
       SEARCH_ARGUMENTS.each { |k, v| params[k] = options[v] if options[v] }
@@ -277,10 +277,9 @@ module Kubeclient
     end
 
     # Accepts the following options:
-    #   :as (symbol) - if :raw, return the raw response body (as a string)
-    #
-    #   Default response type will return an entity as a  RecursiveOpenStruct
-    #   (:ros) object, unless `:as` is passed with `:raw`.
+    #   :as (:raw|:ros) - defaults to :ros
+    #     :raw - return the raw response body as a string
+    #     :ros - return a collection of RecursiveOpenStruct objects
     def get_entity(resource_name, name, namespace = nil, options = {})
       ns_prefix = build_namespace_prefix(namespace)
       response = handle_exception do

--- a/test/test_namespace.rb
+++ b/test/test_namespace.rb
@@ -32,9 +32,10 @@ class TestNamespace < MiniTest::Test
     stub_request(:get, %r{/api/v1$})
       .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
     stub_request(:delete, %r{/namespaces})
-      .to_return(status: 200)
+      .to_return(body: open_test_file('namespace.json'), status: 200)
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
-    client.delete_namespace(our_namespace.metadata.name)
+    our_namespace = client.delete_namespace(our_namespace.metadata.name)
+    assert_kind_of(RecursiveOpenStruct, our_namespace)
 
     assert_requested(
       :delete,

--- a/test/test_replication_controller.rb
+++ b/test/test_replication_controller.rb
@@ -41,9 +41,9 @@ class TestReplicationController < MiniTest::Test
     stub_request(:delete,
                  'http://localhost:8080/api/v1/namespaces/default/replicationcontrollers/frontendController')
       .with(body: opts.to_hash.to_json)
-      .to_return(status: 200, body: '', headers: {})
-
-    client.delete_replication_controller('frontendController', 'default', delete_options: opts)
+      .to_return(status: 200, body: open_test_file('replication_controller.json'), headers: {})
+    rc = client.delete_replication_controller('frontendController', 'default', delete_options: opts)
+    assert_kind_of(RecursiveOpenStruct, rc)
 
     assert_requested(:delete,
                      'http://localhost:8080/api/v1/namespaces/default/replicationcontrollers/frontendController',

--- a/test/test_secret.rb
+++ b/test/test_secret.rb
@@ -31,10 +31,11 @@ class TestSecret < MiniTest::Test
                  status: 200)
 
     stub_request(:delete, %r{/secrets})
-      .to_return(status: 200)
+      .to_return(status: 200, body: open_test_file('created_secret.json'))
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
-    client.delete_secret('test-secret', 'dev')
+    secret = client.delete_secret('test-secret', 'dev')
+    assert_kind_of(RecursiveOpenStruct, secret)
 
     assert_requested(:delete,
                      'http://localhost:8080/api/v1/namespaces/dev/secrets/test-secret',

--- a/test/test_service.rb
+++ b/test/test_service.rb
@@ -164,10 +164,11 @@ class TestService < MiniTest::Test
       .to_return(body: open_test_file('core_api_resource_list.json'),
                  status: 200)
     stub_request(:delete, %r{/namespaces/default/services})
-      .to_return(status: 200)
+      .to_return(body: open_test_file('service.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
-    client.delete_service(our_service.name, 'default')
+    our_service = client.delete_service(our_service.name, 'default')
+    assert_kind_of(RecursiveOpenStruct, our_service)
 
     assert_requested(:delete,
                      'http://localhost:8080/api/v1/namespaces/default/services/redis-service',
@@ -224,7 +225,8 @@ class TestService < MiniTest::Test
       .to_return(body: open_test_file('service_update.json'), status: 201)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
-    client.update_service(service)
+    service = client.update_service(service)
+    assert_kind_of(RecursiveOpenStruct, service)
 
     assert_requested(:put, expected_url, times: 1) do |req|
       data = JSON.parse(req.body)
@@ -250,7 +252,8 @@ class TestService < MiniTest::Test
       .to_return(body: open_test_file('service_update.json'), status: 201)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
-    client.update_service(service)
+    service = client.update_service(service)
+    assert_kind_of(RecursiveOpenStruct, service)
 
     assert_requested(:put, expected_url, times: 1) do |req|
       data = JSON.parse(req.body)
@@ -283,7 +286,8 @@ class TestService < MiniTest::Test
     }
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
-    client.patch_service(name, patch, 'development')
+    service = client.patch_service(name, patch, 'development')
+    assert_kind_of(RecursiveOpenStruct, service)
 
     assert_requested(:patch, expected_url, times: 1) do |req|
       data = JSON.parse(req.body)


### PR DESCRIPTION
Fix #196 

Public methods update_x delete_x and patch_x should all return RecursiveOpenStruct like get_x and watches.

I did not add the `:as => :raw` options in these cases because the response is small and limited so I do not expect to hit performance problems there. Anyway since the `:as` is an additional option it can be added in a minor version.