### PR TITLE
Add ruby 2.5.0 to Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - "2.2"
   - "2.3.0"
   - "2.4.0"
+  - "2.5.0"
 sudo: false
 cache: bundler
 script: bundle exec rake $TASK


### PR DESCRIPTION
@moolitayer please review/merge.  Ruby 2.5.0 hot from the oven :-)
Tests pass on Travis and locally for me.
I propose v2.x/yes?