### PR TITLE
Read and store namespace in Config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,18 @@ You can also load your JSONified config in from an ENV variable (e.g. `KUBE_CONF
 Kubeclient::Config.new(JSON.parse(ENV['KUBE_CONFIG']), nil)
 ```
 
+#### namespace
+
+Additionally, the `config.context` object will contain a `namespace` attribute, if it was defined in the file.
+It is recommended that you use this namespace when issuing API commands below.
+This is the same behavior that is implemented by `kubectl` command.
+
+You can read it as follows:
+
+```ruby
+puts config.context.namespace
+```
+
 ### Supported kubernetes versions
 
 For 1.1 only the core api v1 is supported, all api groups are supported in later versions.

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -44,6 +44,7 @@ class KubeclientConfigTest < MiniTest::Test
   def check_context(context, ssl: true)
     assert_equal('https://localhost:8443', context.api_endpoint)
     assert_equal('v1', context.api_version)
+    assert_equal('default', context.namespace)
     if ssl
       assert_equal(OpenSSL::SSL::VERIFY_PEER, context.ssl_options[:verify_ssl])
       assert_kind_of(OpenSSL::X509::Store, context.ssl_options[:cert_store])


### PR DESCRIPTION
If a namespace exists in a `KUBECONFIG` file, it will be read and stored
in the `Kubeclient::Config::Context` object. This is what `kubectl` implements
when reading from config files and automatically applies on all
commands.

Example usage:

    puts config.context.namespace

Tests modified to add an assertion in `test_config.rb:check_context`. All pass.
