### PR TITLE
Update recursive-open-struct dependency

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'rubocop', '= 0.49.1'
   spec.add_dependency 'rest-client', '~> 2.0'
-  spec.add_dependency 'recursive-open-struct', '~> 1.0.4'
+  spec.add_dependency 'recursive-open-struct', '~> 1.0', '>= 1.0.4'
   spec.add_dependency 'http', '~> 2.2.2'
 end


### PR DESCRIPTION
They have not introduced a breaking change in the past in minor releases https://github.com/aetherknight/recursive-open-struct/blob/master/CHANGELOG.md

Asking them to be sure https://github.com/aetherknight/recursive-open-struct/issues/57 

Debian already has 1.1.0 and it would be good to sync versions