### PR TITLE
catch standard error when watch stream finished

### DIFF
--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -27,7 +27,7 @@ module Kubeclient
             yield @formatter.call(line.chomp)
           end
         end
-      rescue IOError, Errno::EBADF
+      rescue StandardError
         raise unless @finished
       end
 

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -132,10 +132,10 @@ class TestWatch < MiniTest::Test
     client = Kubeclient::Client.new(api_host, 'v1')
     watcher = client.watch_events
 
-    # explodes when Errno::EBADF is not caught
+    # explodes when StandardError is not caught
     watcher.each do
       watcher.finish
-      raise Errno::EBADF
+      raise StandardError
     end
 
     assert_requested(:get, "#{api_host}/v1/watch/events", times: 1)


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1507528

Same as #280 
based on comment here: https://github.com/abonas/kubeclient/pull/280#issuecomment-380044908 

@moolitayer @cben @agrare Please review