### PR TITLE
update http gem to 3.0+

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-rg'
-  spec.add_development_dependency 'webmock', '~> 3.0.1'
+  spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'rubocop', '= 0.49.1'
   spec.add_development_dependency 'googleauth', '~> 0.5.1'

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'recursive-open-struct', '~> 1.0', '>= 1.0.4'
-  spec.add_dependency 'http', '~> 2.2.2'
+  spec.add_dependency 'http', '~> 3.0'
 end


### PR DESCRIPTION
Only breaking change is drop of support for ruby 2.0 and 2.1 which we don't care. Fixes #320 
twitter gem already moved to http 3.0 and this will help in debian packaging. We prefer to maintain only a single version of http.