### PR TITLE
Remove special handling for services when building the proxy URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ puts config.context.namespace
 
 ### Supported kubernetes versions
 
-For 1.1 only the core api v1 is supported, all api groups are supported in later versions.
+The last 3 minor versions are supported, although older versions may also work. This matches the [official support policy for Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#supported-releases-and-component-skew).
 
 ## Examples:
 

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ puts config.context.namespace
 
 ### Supported kubernetes versions
 
-The last 3 minor versions are supported, although older versions may also work. This matches the [official support policy for Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#supported-releases-and-component-skew).
+We try to support the last 3 minor versions, matching the [official support policy for Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#supported-releases-and-component-skew). Kubernetes 1.2 and below have known issues and are unsupported.
 
 ## Examples:
 

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -399,12 +399,7 @@ module Kubeclient
           @entities[kind.to_s].resource_name
         end
       ns_prefix = build_namespace_prefix(namespace)
-      # TODO: Change this once services supports the new scheme
-      if entity_name_plural == 'pods'
-        rest_client["#{ns_prefix}#{entity_name_plural}/#{name}:#{port}/proxy"].url
-      else
-        rest_client["proxy/#{ns_prefix}#{entity_name_plural}/#{name}:#{port}"].url
-      end
+      rest_client["#{ns_prefix}#{entity_name_plural}/#{name}:#{port}/proxy"].url
     end
 
     def process_template(template)

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -710,12 +710,12 @@ class KubeclientTest < MiniTest::Test
 
     client = Kubeclient::Client.new('http://host:8080', 'v1')
     assert_equal(
-      'http://host:8080/api/v1/proxy/namespaces/ns/services/srvname:srvportname',
+      'http://host:8080/api/v1/namespaces/ns/services/srvname:srvportname/proxy',
       client.proxy_url('service', 'srvname', 'srvportname', 'ns')
     )
 
     assert_equal(
-      'http://host:8080/api/v1/proxy/namespaces/ns/services/srvname:srvportname',
+      'http://host:8080/api/v1/namespaces/ns/services/srvname:srvportname/proxy',
       client.proxy_url('services', 'srvname', 'srvportname', 'ns')
     )
 
@@ -731,23 +731,23 @@ class KubeclientTest < MiniTest::Test
 
     # Check no namespace provided
     assert_equal(
-      'http://host:8080/api/v1/proxy/nodes/srvname:srvportname',
+      'http://host:8080/api/v1/nodes/srvname:srvportname/proxy',
       client.proxy_url('nodes', 'srvname', 'srvportname')
     )
 
     assert_equal(
-      'http://host:8080/api/v1/proxy/nodes/srvname:srvportname',
+      'http://host:8080/api/v1/nodes/srvname:srvportname/proxy',
       client.proxy_url('node', 'srvname', 'srvportname')
     )
 
     # Check integer port
     assert_equal(
-      'http://host:8080/api/v1/proxy/nodes/srvname:5001',
+      'http://host:8080/api/v1/nodes/srvname:5001/proxy',
       client.proxy_url('nodes', 'srvname', 5001)
     )
 
     assert_equal(
-      'http://host:8080/api/v1/proxy/nodes/srvname:5001',
+      'http://host:8080/api/v1/nodes/srvname:5001/proxy',
       client.proxy_url('node', 'srvname', 5001)
     )
   end


### PR DESCRIPTION
This removes the special handling that is present when building the proxy URL for everything except pods. The proxy endpoint has been removed in 1.10, based on this PR: https://github.com/kubernetes/kubernetes/pull/59884

From the PR, it seems like versions 1.2 and above should be compatible with the new URL scheme, although I don't have access to clusters that old to test.

Fixes #322 