### PR TITLE
Adds support for tail_lines in get_pod_log

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,12 @@ client.get_pod_log('pod-name', 'default', timestamps: true, since_time: '2018-04
 ```
 `since_time` can be a a `Time`, `DateTime` or `String` formatted according to RFC3339
 
+Kubernetes can fetch a specific number of lines from the end of the logs:
+```ruby
+client.get_pod_log('pod-name', 'default', tail_lines: 10)
+# => "..."
+```
+
 You can also watch the logs of a pod to get a stream of data:
 
 ```ruby

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -361,12 +361,14 @@ module Kubeclient
     end
 
     def get_pod_log(pod_name, namespace,
-                    container: nil, previous: false, timestamps: false, since_time: nil)
+                    container: nil, previous: false,
+                    timestamps: false, since_time: nil, tail_lines: nil)
       params = {}
       params[:previous] = true if previous
       params[:container] = container if container
       params[:timestamps] = timestamps if timestamps
       params[:sinceTime] = format_datetime(since_time) if since_time
+      params[:tailLines] = tail_lines if tail_lines
 
       ns = build_namespace_prefix(namespace)
       handle_exception do

--- a/test/test_pod_log.rb
+++ b/test/test_pod_log.rb
@@ -50,6 +50,25 @@ class TestPodLog < MiniTest::Test
                      times: 1)
   end
 
+  def test_get_pod_log_tail_lines
+    selected_lines = open_test_file('pod_log.txt').to_a[-2..1].join
+
+    stub_request(:get, %r{/namespaces/default/pods/[a-z0-9-]+/log})
+      .to_return(body: selected_lines,
+                 status: 200)
+
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+    retrieved_log = client.get_pod_log('redis-master-pod',
+                                       'default',
+                                       tail_lines: 2)
+
+    assert_equal(selected_lines, retrieved_log)
+
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1/namespaces/default/pods/redis-master-pod/log?tailLines=2',
+                     times: 1)
+  end
+
   def test_watch_pod_log
     expected_lines = open_test_file('pod_log.txt').read.split("\n")
 


### PR DESCRIPTION
## Why is this PR needed

From https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#read-log:

> If set, the number of lines from the end of the logs to show. If not specified, logs are shown from the creation of the container or sinceSeconds or sinceTime

This will allow us to fetch only the tail of the log.