### PR TITLE
Start testing ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - "2.3.0"
   - "2.4.0"
   - "2.5.0"
+  - "2.6.0-preview1"
 sudo: false
 cache: bundler
 script: bundle exec rake $TASK


### PR DESCRIPTION
2.6 is not released yet but we can start testing [2.6.0-preview1](https://www.ruby-lang.org/en/news/2018/02/24/ruby-2-6-0-preview1-released/).
