### PR TITLE
[WIP] [EXPERIMENT] Don't send kind, apiVersion in create POST

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -306,17 +306,11 @@ module Kubeclient
     def create_entity(entity_type, resource_name, entity_config)
       # Duplicate the entity_config to a hash so that when we assign
       # kind and apiVersion, this does not mutate original entity_config obj.
+      # TODO: skip?
       hash = entity_config.to_hash
 
       ns_prefix = build_namespace_prefix(hash[:metadata][:namespace])
 
-      # TODO: temporary solution to add "kind" and apiVersion to request
-      # until this issue is solved
-      # https://github.com/GoogleCloudPlatform/kubernetes/issues/6439
-      # TODO: #2 solution for
-      # https://github.com/kubernetes/kubernetes/issues/8115
-      hash[:kind] = (entity_type.eql?('Endpoint') ? 'Endpoints' : entity_type)
-      hash[:apiVersion] = @api_group + @api_version
       response = handle_exception do
         rest_client[ns_prefix + resource_name]
           .post(hash.to_json, { 'Content-Type' => 'application/json' }.merge(@headers))


### PR DESCRIPTION
Can we revert #58?

Seems https://github.com/kubernetes/kubernetes/issues/6439 fixed - from which kubernetes version?
https://github.com/kubernetes/kubernetes/pull/10200 landed in v1.1.0.

Works for me on OpenShift 3.10-ish:

```
[8] pry(main)> kclient.create_service(Kubeclient::Resource.new(metadata: {namespace: 'default', name: 'foo'}, spec: {ports: [{port: 80}]}))
RestClient.post "https://internal-api.bpaskinc.origin-gce.dev.openshift.com:8443/api/v1/namespaces/default/services", "{\"metadata\":{\"namespace\":\"default\",\"name\":\"foo\"},\"spec\":{\"ports\":[{\"port\":80}]}}", "Accept"=>"*/*", "Accept-Encoding"=>"gzip, deflate", "Content-Length"=>"80", "Content-Type"=>"application/json", "User-Agent"=>"rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.1p111"
=> #<Kubeclient::Resource kind="Service", apiVersion="v1", metadata={:name=>"foo", :namespace=>"default", :selfLink=>"/api/v1/namespaces/default/services/foo", :uid=>"b2b41793-64e1-11e8-9540-42010a8e0002", :resourceVersion=>"45722", :creationTimestamp=>"2018-05-31T14:48:36Z"}, spec={:ports=>[{:protocol=>"TCP", :port=>80, :targetPort=>80}], :clusterIP=>"172.30.186.136", :type=>"ClusterIP", :sessionAffinity=>"None"}, status={:loadBalancer=>{}}>
```
(note POST body didn't include kind nor apiVersion)

Motivation: if we don't need to know apiVersion, this may (?) open up #284, #318, and other issues to simpler interface.
- I'm not sure yet if we should commit to "we don't need to know apiVersion"
- OTOH, I suspect we could infer apiVersion from discovery anyway?