### PR TITLE
[security] Config.read: Use YAML.safe_load to avoid arbitrary Ruby class instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
+## Unreleased
+
+### Security
+- Fixed `Kubeclient::Config.read` to use `YAML.safe_load` (#334).
+
+  Previously, could deserialize arbitrary ruby classes.  The risk depends on ruby classes available in the application; sometimes a class may have side effects - up to arbitrary code execution - when instantiated and/or built up with `x[key] = value` during YAML parsing.
+
+  Despite this fix, using config from untrusted sources is not recommended.
+
 ## 3.1.0 - 2018-05-27
 
 ### Fixed

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -25,7 +25,7 @@ module Kubeclient
     end
 
     def self.read(filename)
-      Config.new(YAML.load_file(filename), File.dirname(filename))
+      Config.new(YAML.safe_load(File.read(filename)), File.dirname(filename))
     end
 
     def contexts


### PR DESCRIPTION
Previously used YAML.load designed for deserialization from trusted sources only, allowing `!ruby/object:AnyClass ...` and other risky constructs.
The risk depends on ruby classes available in the application; sometimes a class may have side effects - up to arbitrary code execution - when instantiated and/or built up with `x[key] = value` during YAML parsing.

\[See https://www.sitepoint.com/anatomy-of-an-exploit-an-in-depth-look-at-the-rails-yaml-vulnerability/ for one detailed example how `YAML.load` made Rails vulnerable, and https://github.com/ruby/psych/issues/119 for more links]

Documented `Config.read` and `Config.new` better.

- Documented when config may read other files from file system.
  Added tests for `Config.new(data, nil)` preventing this (this happens via TypeError, might improve to nicer exception but out of scope here).

- Added warning that despite this fix, using untrusted config remains a questionable idea!

@moolitayer @grosser @pkliczewski @masayag please review.

@moolitayer, I want to release this quickly, possibly by myself.  ~~(Hence CHANGELOG and version bump all in one PR.)~~