### PR TITLE
Fix #337 Config.read regresion on YAML timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
-## 3.1.1 - 2018-06-01
+## Unreleased
+
+### Fixed
+- Fixed `Kubeclient::Config.read` regression, no longer crashes on YAML timestamps (#338).
+
+## 3.1.1 - 2018-06-01 — REGRESSION
+
+In this version `Kubeclient::Config.read` raises Psych::DisallowedClass on legal yaml configs containing a timestamp, for example gcp access-token expiry (#337).
 
 ### Security
-- Fixed `Kubeclient::Config.read` to use `YAML.safe_load` (#334).
+- Changed `Kubeclient::Config.read` to use `YAML.safe_load` (#334).
 
   Previously, could deserialize arbitrary ruby classes.  The risk depends on ruby classes available in the application; sometimes a class may have side effects - up to arbitrary code execution - when instantiated and/or built up with `x[key] = value` during YAML parsing.
 

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -25,7 +25,8 @@ module Kubeclient
     end
 
     def self.read(filename)
-      Config.new(YAML.safe_load(File.read(filename)), File.dirname(filename))
+      parsed = YAML.safe_load(File.read(filename), [Date, Time])
+      Config.new(parsed, File.dirname(filename))
     end
 
     def contexts

--- a/test/config/timestamps.kubeconfig
+++ b/test/config/timestamps.kubeconfig
@@ -1,0 +1,25 @@
+apiVersion: v1
+users:
+- name: gke_username
+  user:
+    auth-provider:
+      config:
+        access-token: REDACTED
+        cmd-args: config config-helper --format=json
+        cmd-path: /Users/tannerbruce/opt/google-cloud-sdk/bin/gcloud
+        expiry: 2018-07-07T18:25:36Z
+        expiry-key: '{.credential.token_expiry}'
+        token-key: '{.credential.access_token}'
+      name: gcp
+
+# More syntaxes from go-yaml tests, hopefully covering all types possible in kubeconfig
+IPv4: 1.2.3.4
+Duration: 3s
+date_only: 2015-01-01
+rfc3339: 2015-02-24T18:19:39Z
+longer: 2015-02-24T18:19:39.123456789-03:00
+shorter: 2015-2-3T3:4:5Z
+iso_lower_t: 2015-02-24t18:19:39Z
+space_no_tz: 2015-02-24 18:19:39
+space_tz: 2001-12-14 21:59:43.10 -5
+timestamp_like_string: "2015-02-24T18:19:39Z"

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -68,6 +68,11 @@ class KubeclientConfigTest < MiniTest::Test
     assert_equal('pAssw0rd123', context.auth_options[:password])
   end
 
+  def test_timestamps
+    # Test YAML parsing doesn't crash on YAML timestamp syntax.
+    Kubeclient::Config.read(config_file('timestamps.kubeconfig'))
+  end
+
   private
 
   def check_context(context, ssl: true)


### PR DESCRIPTION
Fixes #337 `Config.read` crashing on YAML timestamp, introduced in #334.

Could I be missing other types that safe_load forbids by default?
Added other YAML syntaxes from go-yaml tests, on the assumption these *might* appear in kubeconfig...
\[https://github.com/go-yaml/yaml — decode_test.go, encode_test.go]

@tanner-bruce @grosser @moolitayer please review