### PR TITLE
Bump for 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
-## Unreleased
+## 3.1.2 — 2018-06-11
 
 ### Fixed
 - Fixed `Kubeclient::Config.read` regression, no longer crashes on YAML timestamps (#338).

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -1,4 +1,4 @@
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '3.1.1'.freeze
+  VERSION = '3.1.2'.freeze
 end


### PR DESCRIPTION
@moolitayer Please review.

On version number: in retrospect previous release should probably have been 3.2.0, as I was aware I can't be 100% sure #334 will be backward compatible.
Anyway this one is clear bug fix, 3.1.1 -> 3.1.2 and hopefully now 3.1.0 -> 3.1.2 should be safe upgrades.