### PR TITLE
Changelog & bump for 4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
+## 4.0.0 — 2018-07-23
+
+### Removed
+- Bumped officially supported kubernetes versions to >= 1.3.
+- Specifically `proxy_url` no longer works for <= 1.2 (#323).
+
+### Fixed
+- `proxy_url` now works for kubernetes 1.10 and later (#323).
+
+### Changed
+- Switched `http` gem dependency from 2.y to 3.y (#321).
+
 ## 3.1.2 — 2018-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -314,7 +314,9 @@ puts config.context.namespace
 
 ### Supported kubernetes versions
 
-We try to support the last 3 minor versions, matching the [official support policy for Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#supported-releases-and-component-skew). Kubernetes 1.2 and below have known issues and are unsupported.
+We try to support the last 3 minor versions, matching the [official support policy for Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#supported-releases-and-component-skew).
+Kubernetes 1.2 and below have known issues and are unsupported.
+Kubernetes 1.3 presumed to still work although nobody is really testing on such old versions...
 
 ## Examples:
 
@@ -565,6 +567,10 @@ client.process_template template
 
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 See [CHANGELOG.md](CHANGELOG.md) for full changelog.
+
+#### past version 4.0
+
+Old kubernetes versions < 1.3 no longer supported.
 
 #### past version 3.0
 

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -1,4 +1,4 @@
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '3.1.2'.freeze
+  VERSION = '4.0.0'.freeze
 end


### PR DESCRIPTION
Includes #323 fixing #322 (finally! sorry :flushed:) and #321.
Bumping major because we're knowingly breaking a k8s version that previously was believed to work (even if so old it's hard to test).

@lambertjosh @grosser @pravi please review.