### PR TITLE
Tolerate lowercase kubenetes `kind`s

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -138,7 +138,7 @@ module Kubeclient
       # See: https://github.com/kubernetes/kubernetes/issues/8115
       kind = kind[0..-2] if %w[Endpoints SecurityContextConstraints].include?(kind)
 
-      prefix = kind[0..kind.rindex(/[A-Z]/)] # NetworkP
+      prefix = kind =~ /[A-Z]/ ? kind[0..kind.rindex(/[A-Z]/)] : kind # NetworkP
       m = name.match(/^#{prefix.downcase}(.*)$/)
       m && OpenStruct.new(
         entity_type:   kind, # ComponentStatus

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -33,6 +33,8 @@ class CommonTest < MiniTest::Test
       BuildConfig build_config
       Image image
       ImageStream image_stream
+      dogstatsd dogstatsd
+      HTTPAPISpecBinding httpapispec_binding
     ].each_slice(2) do |singular, plural|
       assert_equal(Kubeclient::ClientMixin.underscore_entity(singular), plural)
     end


### PR DESCRIPTION
- Istio stresses the type system by using unexpected kind definitions as explained in [issue 360](https://github.com/abonas/kubeclient/issues/360).

