### PR TITLE
Simpler derivation of singular & plural method names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 
 ### Fixed
 - Support custom resources with lowercase `kind` (#361).
+- `create_security_context_constraint` now works (#366).
+- `get_security_context_constraints.kind`, `get_endpoints.kind` are now plural as in kubernetes (#366).
 
 ### Added
 - Add support for retrieving large lists of objects in chunks (#356).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 
 ## Unreleased
 
+### Fixed
+- Support custom resources with lowercase `kind` (#361).
+
 ### Added
-- Add support for retrieving large lists of objects in chunks (#356)
+- Add support for retrieving large lists of objects in chunks (#356).
 
 ## 4.0.0 — 2018-07-23
 
@@ -86,6 +89,6 @@ No changes since 2.5.0, fixed packaging mistake.
 
 ### Added
 
-- `as: raw` option for `get_*` methods returning a string (#262 via #271)
+- `as: raw` option for `get_*` methods returning a string (#262 via #271).
 
 ## 2.4.0 - 2017-05-10

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -435,7 +435,7 @@ module Kubeclient
 
     private
 
-    # Format ditetime according to RFC3339
+    # Format datetime according to RFC3339
     def format_datetime(value)
       case value
       when DateTime, Time

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -338,9 +338,7 @@ module Kubeclient
       # TODO: temporary solution to add "kind" and apiVersion to request
       # until this issue is solved
       # https://github.com/GoogleCloudPlatform/kubernetes/issues/6439
-      # TODO: #2 solution for
-      # https://github.com/kubernetes/kubernetes/issues/8115
-      hash[:kind] = (entity_type.eql?('Endpoint') ? 'Endpoints' : entity_type)
+      hash[:kind] = entity_type
       hash[:apiVersion] = @api_group + @api_version
       response = handle_exception do
         rest_client[ns_prefix + resource_name]

--- a/test/json/config.istio.io_api_resource_list.json
+++ b/test/json/config.istio.io_api_resource_list.json
@@ -1,0 +1,679 @@
+{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "groupVersion": "config.istio.io/v1alpha2",
+  "resources": [
+    {
+      "name": "metrics",
+      "singularName": "metric",
+      "namespaced": true,
+      "kind": "metric",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "servicecontrolreports",
+      "singularName": "servicecontrolreport",
+      "namespaced": true,
+      "kind": "servicecontrolreport",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "opas",
+      "singularName": "opa",
+      "namespaced": true,
+      "kind": "opa",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "redisquotas",
+      "singularName": "redisquota",
+      "namespaced": true,
+      "kind": "redisquota",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "authorizations",
+      "singularName": "authorization",
+      "namespaced": true,
+      "kind": "authorization",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "listentries",
+      "singularName": "listentry",
+      "namespaced": true,
+      "kind": "listentry",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "logentries",
+      "singularName": "logentry",
+      "namespaced": true,
+      "kind": "logentry",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "tracespans",
+      "singularName": "tracespan",
+      "namespaced": true,
+      "kind": "tracespan",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "quotaspecs",
+      "singularName": "quotaspec",
+      "namespaced": true,
+      "kind": "QuotaSpec",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "fluentds",
+      "singularName": "fluentd",
+      "namespaced": true,
+      "kind": "fluentd",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "rbacs",
+      "singularName": "rbac",
+      "namespaced": true,
+      "kind": "rbac",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "checknothings",
+      "singularName": "checknothing",
+      "namespaced": true,
+      "kind": "checknothing",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "edges",
+      "singularName": "edge",
+      "namespaced": true,
+      "kind": "edge",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "apikeys",
+      "singularName": "apikey",
+      "namespaced": true,
+      "kind": "apikey",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "kuberneteses",
+      "singularName": "kubernetes",
+      "namespaced": true,
+      "kind": "kubernetes",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "httpapispecs",
+      "singularName": "httpapispec",
+      "namespaced": true,
+      "kind": "HTTPAPISpec",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "attributemanifests",
+      "singularName": "attributemanifest",
+      "namespaced": true,
+      "kind": "attributemanifest",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "kubernetesenvs",
+      "singularName": "kubernetesenv",
+      "namespaced": true,
+      "kind": "kubernetesenv",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "listcheckers",
+      "singularName": "listchecker",
+      "namespaced": true,
+      "kind": "listchecker",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "quotas",
+      "singularName": "quota",
+      "namespaced": true,
+      "kind": "quota",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "instances",
+      "singularName": "instance",
+      "namespaced": true,
+      "kind": "instance",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "memquotas",
+      "singularName": "memquota",
+      "namespaced": true,
+      "kind": "memquota",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "noops",
+      "singularName": "noop",
+      "namespaced": true,
+      "kind": "noop",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "prometheuses",
+      "singularName": "prometheus",
+      "namespaced": true,
+      "kind": "prometheus",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "solarwindses",
+      "singularName": "solarwinds",
+      "namespaced": true,
+      "kind": "solarwinds",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "cloudwatches",
+      "singularName": "cloudwatch",
+      "namespaced": true,
+      "kind": "cloudwatch",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "reportnothings",
+      "singularName": "reportnothing",
+      "namespaced": true,
+      "kind": "reportnothing",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "stackdrivers",
+      "singularName": "stackdriver",
+      "namespaced": true,
+      "kind": "stackdriver",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "statsds",
+      "singularName": "statsd",
+      "namespaced": true,
+      "kind": "statsd",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "httpapispecbindings",
+      "singularName": "httpapispecbinding",
+      "namespaced": true,
+      "kind": "HTTPAPISpecBinding",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "quotaspecbindings",
+      "singularName": "quotaspecbinding",
+      "namespaced": true,
+      "kind": "QuotaSpecBinding",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "bypasses",
+      "singularName": "bypass",
+      "namespaced": true,
+      "kind": "bypass",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "circonuses",
+      "singularName": "circonus",
+      "namespaced": true,
+      "kind": "circonus",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "deniers",
+      "singularName": "denier",
+      "namespaced": true,
+      "kind": "denier",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "signalfxs",
+      "singularName": "signalfx",
+      "namespaced": true,
+      "kind": "signalfx",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "adapters",
+      "singularName": "adapter",
+      "namespaced": true,
+      "kind": "adapter",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "servicecontrols",
+      "singularName": "servicecontrol",
+      "namespaced": true,
+      "kind": "servicecontrol",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "templates",
+      "singularName": "template",
+      "namespaced": true,
+      "kind": "template",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "handlers",
+      "singularName": "handler",
+      "namespaced": true,
+      "kind": "handler",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "rules",
+      "singularName": "rule",
+      "namespaced": true,
+      "kind": "rule",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "dogstatsds",
+      "singularName": "dogstatsd",
+      "namespaced": true,
+      "kind": "dogstatsd",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "stdios",
+      "singularName": "stdio",
+      "namespaced": true,
+      "kind": "stdio",
+      "verbs": [
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "create",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/test/json/created_security_context_constraint.json
+++ b/test/json/created_security_context_constraint.json
@@ -1,0 +1,65 @@
+{
+    "allowHostDirVolumePlugin": false,
+    "allowHostIPC": false,
+    "allowHostNetwork": false,
+    "allowHostPID": false,
+    "allowHostPorts": false,
+    "allowPrivilegedContainer": false,
+    "allowedCapabilities": null,
+    "allowedFlexVolumes": null,
+    "apiVersion": "security.openshift.io/v1",
+    "defaultAddCapabilities": null,
+    "fsGroup": {
+        "type": "RunAsAny"
+    },
+    "groups": [],
+    "kind": "SecurityContextConstraints",
+    "metadata": {
+        "creationTimestamp": "2018-11-23T10:01:42Z",
+        "name": "teleportation",
+        "resourceVersion": "5274",
+        "selfLink": "/apis/security.openshift.io/v1/securitycontextconstraints/teleportation",
+        "uid": "c6e8e2ec-ef06-11e8-b4c0-68f728fac3ab"
+    },
+    "priority": null,
+    "readOnlyRootFilesystem": false,
+    "requiredDropCapabilities": null,
+    "runAsUser": {
+        "type": "MustRunAs"
+    },
+    "seLinuxContext": {
+        "type": "MustRunAs"
+    },
+    "supplementalGroups": {
+        "type": "RunAsAny"
+    },
+    "users": [],
+    "volumes": [
+        "awsElasticBlockStore",
+        "azureDisk",
+        "azureFile",
+        "cephFS",
+        "cinder",
+        "configMap",
+        "downwardAPI",
+        "emptyDir",
+        "fc",
+        "flexVolume",
+        "flocker",
+        "gcePersistentDisk",
+        "gitRepo",
+        "glusterfs",
+        "iscsi",
+        "nfs",
+        "persistentVolumeClaim",
+        "photonPersistentDisk",
+        "portworxVolume",
+        "projected",
+        "quobyte",
+        "rbd",
+        "scaleIO",
+        "secret",
+        "storageOS",
+        "vsphere"
+    ]
+}

--- a/test/json/security.openshift.io_api_resource_list.json
+++ b/test/json/security.openshift.io_api_resource_list.json
@@ -1,0 +1,69 @@
+{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "groupVersion": "security.openshift.io/v1",
+  "resources": [
+    {
+      "name": "podsecuritypolicyreviews",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "PodSecurityPolicyReview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "podsecuritypolicyselfsubjectreviews",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "PodSecurityPolicySelfSubjectReview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "podsecuritypolicysubjectreviews",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "PodSecurityPolicySubjectReview",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "rangeallocations",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "RangeAllocation",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "securitycontextconstraints",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "SecurityContextConstraints",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "scc"
+      ]
+    }
+  ]
+}

--- a/test/json/security_context_constraint_list.json
+++ b/test/json/security_context_constraint_list.json
@@ -1,0 +1,375 @@
+{
+  "kind": "SecurityContextConstraintsList",
+  "apiVersion": "security.openshift.io/v1",
+  "metadata": {
+    "selfLink": "/apis/security.openshift.io/v1/securitycontextconstraints",
+    "resourceVersion": "5751"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "anyuid",
+        "selfLink": "/apis/security.openshift.io/v1/securitycontextconstraints/anyuid",
+        "uid": "12ba8540-ef00-11e8-b4c0-68f728fac3ab",
+        "resourceVersion": "71",
+        "creationTimestamp": "2018-11-23T09:13:42Z",
+        "annotations": {
+          "kubernetes.io/description": "anyuid provides all features of the restricted SCC but allows users to run with any UID and any GID."
+        }
+      },
+      "priority": 10,
+      "allowPrivilegedContainer": false,
+      "defaultAddCapabilities": null,
+      "requiredDropCapabilities": [
+        "MKNOD"
+      ],
+      "allowedCapabilities": null,
+      "allowHostDirVolumePlugin": false,
+      "volumes": [
+        "configMap",
+        "downwardAPI",
+        "emptyDir",
+        "persistentVolumeClaim",
+        "projected",
+        "secret"
+      ],
+      "allowedFlexVolumes": null,
+      "allowHostNetwork": false,
+      "allowHostPorts": false,
+      "allowHostPID": false,
+      "allowHostIPC": false,
+      "seLinuxContext": {
+        "type": "MustRunAs"
+      },
+      "runAsUser": {
+        "type": "RunAsAny"
+      },
+      "supplementalGroups": {
+        "type": "RunAsAny"
+      },
+      "fsGroup": {
+        "type": "RunAsAny"
+      },
+      "readOnlyRootFilesystem": false,
+      "users": [],
+      "groups": [
+        "system:cluster-admins"
+      ]
+    },
+    {
+      "metadata": {
+        "name": "hostaccess",
+        "selfLink": "/apis/security.openshift.io/v1/securitycontextconstraints/hostaccess",
+        "uid": "12b5b3a2-ef00-11e8-b4c0-68f728fac3ab",
+        "resourceVersion": "69",
+        "creationTimestamp": "2018-11-23T09:13:42Z",
+        "annotations": {
+          "kubernetes.io/description": "hostaccess allows access to all host namespaces but still requires pods to be run with a UID and SELinux context that are allocated to the namespace. WARNING: this SCC allows host access to namespaces, file systems, and PIDS.  It should only be used by trusted pods.  Grant with caution."
+        }
+      },
+      "priority": null,
+      "allowPrivilegedContainer": false,
+      "defaultAddCapabilities": null,
+      "requiredDropCapabilities": [
+        "KILL",
+        "MKNOD",
+        "SETUID",
+        "SETGID"
+      ],
+      "allowedCapabilities": null,
+      "allowHostDirVolumePlugin": true,
+      "volumes": [
+        "configMap",
+        "downwardAPI",
+        "emptyDir",
+        "hostPath",
+        "persistentVolumeClaim",
+        "projected",
+        "secret"
+      ],
+      "allowedFlexVolumes": null,
+      "allowHostNetwork": true,
+      "allowHostPorts": true,
+      "allowHostPID": true,
+      "allowHostIPC": true,
+      "seLinuxContext": {
+        "type": "MustRunAs"
+      },
+      "runAsUser": {
+        "type": "MustRunAsRange"
+      },
+      "supplementalGroups": {
+        "type": "RunAsAny"
+      },
+      "fsGroup": {
+        "type": "MustRunAs"
+      },
+      "readOnlyRootFilesystem": false,
+      "users": [],
+      "groups": []
+    },
+    {
+      "metadata": {
+        "name": "hostmount-anyuid",
+        "selfLink": "/apis/security.openshift.io/v1/securitycontextconstraints/hostmount-anyuid",
+        "uid": "12b512c0-ef00-11e8-b4c0-68f728fac3ab",
+        "resourceVersion": "68",
+        "creationTimestamp": "2018-11-23T09:13:42Z",
+        "annotations": {
+          "kubernetes.io/description": "hostmount-anyuid provides all the features of the restricted SCC but allows host mounts and any UID by a pod.  This is primarily used by the persistent volume recycler. WARNING: this SCC allows host file system access as any UID, including UID 0.  Grant with caution."
+        }
+      },
+      "priority": null,
+      "allowPrivilegedContainer": false,
+      "defaultAddCapabilities": null,
+      "requiredDropCapabilities": [
+        "MKNOD"
+      ],
+      "allowedCapabilities": null,
+      "allowHostDirVolumePlugin": true,
+      "volumes": [
+        "configMap",
+        "downwardAPI",
+        "emptyDir",
+        "hostPath",
+        "nfs",
+        "persistentVolumeClaim",
+        "projected",
+        "secret"
+      ],
+      "allowedFlexVolumes": null,
+      "allowHostNetwork": false,
+      "allowHostPorts": false,
+      "allowHostPID": false,
+      "allowHostIPC": false,
+      "seLinuxContext": {
+        "type": "MustRunAs"
+      },
+      "runAsUser": {
+        "type": "RunAsAny"
+      },
+      "supplementalGroups": {
+        "type": "RunAsAny"
+      },
+      "fsGroup": {
+        "type": "RunAsAny"
+      },
+      "readOnlyRootFilesystem": false,
+      "users": [
+        "system:serviceaccount:openshift-infra:pv-recycler-controller"
+      ],
+      "groups": []
+    },
+    {
+      "metadata": {
+        "name": "hostnetwork",
+        "selfLink": "/apis/security.openshift.io/v1/securitycontextconstraints/hostnetwork",
+        "uid": "12bb0984-ef00-11e8-b4c0-68f728fac3ab",
+        "resourceVersion": "72",
+        "creationTimestamp": "2018-11-23T09:13:42Z",
+        "annotations": {
+          "kubernetes.io/description": "hostnetwork allows using host networking and host ports but still requires pods to be run with a UID and SELinux context that are allocated to the namespace."
+        }
+      },
+      "priority": null,
+      "allowPrivilegedContainer": false,
+      "defaultAddCapabilities": null,
+      "requiredDropCapabilities": [
+        "KILL",
+        "MKNOD",
+        "SETUID",
+        "SETGID"
+      ],
+      "allowedCapabilities": null,
+      "allowHostDirVolumePlugin": false,
+      "volumes": [
+        "configMap",
+        "downwardAPI",
+        "emptyDir",
+        "persistentVolumeClaim",
+        "projected",
+        "secret"
+      ],
+      "allowedFlexVolumes": null,
+      "allowHostNetwork": true,
+      "allowHostPorts": true,
+      "allowHostPID": false,
+      "allowHostIPC": false,
+      "seLinuxContext": {
+        "type": "MustRunAs"
+      },
+      "runAsUser": {
+        "type": "MustRunAsRange"
+      },
+      "supplementalGroups": {
+        "type": "MustRunAs"
+      },
+      "fsGroup": {
+        "type": "MustRunAs"
+      },
+      "readOnlyRootFilesystem": false,
+      "users": [],
+      "groups": []
+    },
+    {
+      "metadata": {
+        "name": "nonroot",
+        "selfLink": "/apis/security.openshift.io/v1/securitycontextconstraints/nonroot",
+        "uid": "12b37c59-ef00-11e8-b4c0-68f728fac3ab",
+        "resourceVersion": "67",
+        "creationTimestamp": "2018-11-23T09:13:42Z",
+        "annotations": {
+          "kubernetes.io/description": "nonroot provides all features of the restricted SCC but allows users to run with any non-root UID.  The user must specify the UID or it must be specified on the by the manifest of the container runtime."
+        }
+      },
+      "priority": null,
+      "allowPrivilegedContainer": false,
+      "defaultAddCapabilities": null,
+      "requiredDropCapabilities": [
+        "KILL",
+        "MKNOD",
+        "SETUID",
+        "SETGID"
+      ],
+      "allowedCapabilities": null,
+      "allowHostDirVolumePlugin": false,
+      "volumes": [
+        "configMap",
+        "downwardAPI",
+        "emptyDir",
+        "persistentVolumeClaim",
+        "projected",
+        "secret"
+      ],
+      "allowedFlexVolumes": null,
+      "allowHostNetwork": false,
+      "allowHostPorts": false,
+      "allowHostPID": false,
+      "allowHostIPC": false,
+      "seLinuxContext": {
+        "type": "MustRunAs"
+      },
+      "runAsUser": {
+        "type": "MustRunAsNonRoot"
+      },
+      "supplementalGroups": {
+        "type": "RunAsAny"
+      },
+      "fsGroup": {
+        "type": "RunAsAny"
+      },
+      "readOnlyRootFilesystem": false,
+      "users": [],
+      "groups": []
+    },
+    {
+      "metadata": {
+        "name": "privileged",
+        "selfLink": "/apis/security.openshift.io/v1/securitycontextconstraints/privileged",
+        "uid": "12b18f4a-ef00-11e8-b4c0-68f728fac3ab",
+        "resourceVersion": "300",
+        "creationTimestamp": "2018-11-23T09:13:42Z",
+        "annotations": {
+          "kubernetes.io/description": "privileged allows access to all privileged and host features and the ability to run as any user, any group, any fsGroup, and with any SELinux context.  WARNING: this is the most relaxed SCC and should be used only for cluster administration. Grant with caution."
+        }
+      },
+      "priority": null,
+      "allowPrivilegedContainer": true,
+      "defaultAddCapabilities": null,
+      "requiredDropCapabilities": null,
+      "allowedCapabilities": [
+        "*"
+      ],
+      "allowHostDirVolumePlugin": true,
+      "volumes": [
+        "*"
+      ],
+      "allowedFlexVolumes": null,
+      "allowHostNetwork": true,
+      "allowHostPorts": true,
+      "allowHostPID": true,
+      "allowHostIPC": true,
+      "seLinuxContext": {
+        "type": "RunAsAny"
+      },
+      "runAsUser": {
+        "type": "RunAsAny"
+      },
+      "supplementalGroups": {
+        "type": "RunAsAny"
+      },
+      "fsGroup": {
+        "type": "RunAsAny"
+      },
+      "readOnlyRootFilesystem": false,
+      "users": [
+        "system:admin",
+        "system:serviceaccount:openshift-infra:build-controller",
+        "system:serviceaccount:default:pvinstaller",
+        "system:serviceaccount:default:registry",
+        "system:serviceaccount:default:router"
+      ],
+      "groups": [
+        "system:cluster-admins",
+        "system:nodes",
+        "system:masters"
+      ],
+      "seccompProfiles": [
+        "*"
+      ]
+    },
+    {
+      "metadata": {
+        "name": "restricted",
+        "selfLink": "/apis/security.openshift.io/v1/securitycontextconstraints/restricted",
+        "uid": "12b9a842-ef00-11e8-b4c0-68f728fac3ab",
+        "resourceVersion": "70",
+        "creationTimestamp": "2018-11-23T09:13:42Z",
+        "annotations": {
+          "kubernetes.io/description": "restricted denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive SCC and it is used by default for authenticated users."
+        }
+      },
+      "priority": null,
+      "allowPrivilegedContainer": false,
+      "defaultAddCapabilities": null,
+      "requiredDropCapabilities": [
+        "KILL",
+        "MKNOD",
+        "SETUID",
+        "SETGID"
+      ],
+      "allowedCapabilities": null,
+      "allowHostDirVolumePlugin": false,
+      "volumes": [
+        "configMap",
+        "downwardAPI",
+        "emptyDir",
+        "persistentVolumeClaim",
+        "projected",
+        "secret"
+      ],
+      "allowedFlexVolumes": null,
+      "allowHostNetwork": false,
+      "allowHostPorts": false,
+      "allowHostPID": false,
+      "allowHostIPC": false,
+      "seLinuxContext": {
+        "type": "MustRunAs"
+      },
+      "runAsUser": {
+        "type": "MustRunAsRange"
+      },
+      "supplementalGroups": {
+        "type": "RunAsAny"
+      },
+      "fsGroup": {
+        "type": "MustRunAs"
+      },
+      "readOnlyRootFilesystem": false,
+      "users": [],
+      "groups": [
+        "system:authenticated"
+      ]
+    }
+  ]
+}

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -1,3 +1,4 @@
+
 require_relative 'test_helper'
 
 # Unit tests for the common module
@@ -34,9 +35,25 @@ class CommonTest < MiniTest::Test
       Image image
       ImageStream image_stream
       dogstatsd dogstatsd
+      lowerCamelUPPERCase lower_camel_uppercase
       HTTPAPISpecBinding httpapispec_binding
-    ].each_slice(2) do |singular, plural|
-      assert_equal(Kubeclient::ClientMixin.underscore_entity(singular), plural)
+      APIGroup apigroup
+      APIGroupList apigroup_list
+      APIResourceList apiresource_list
+      APIService apiservice
+      APIServiceList apiservice_list
+      APIVersions apiversions
+      OAuthAccessToken oauth_access_token
+      OAuthAccessTokenList oauth_access_token_list
+      OAuthAuthorizeToken oauth_authorize_token
+      OAuthAuthorizeTokenList oauth_authorize_token_list
+      OAuthClient oauth_client
+      OAuthClientAuthorization oauth_client_authorization
+      OAuthClientAuthorizationList oauth_client_authorization_list
+      OAuthClientList oauth_client_list
+    ].each_slice(2) do |kind, expected_underscore|
+      underscore = Kubeclient::ClientMixin.underscore_entity(kind)
+      assert_equal(underscore, expected_underscore)
     end
   end
 

--- a/test/test_component_status.rb
+++ b/test/test_component_status.rb
@@ -3,10 +3,9 @@ require_relative 'test_helper'
 # ComponentStatus tests
 class TestComponentStatus < MiniTest::Test
   def test_get_from_json_v3
+    stub_core_api_list
     stub_request(:get, %r{/componentstatuses})
       .to_return(body: open_test_file('component_status.json'), status: 200)
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     component_status = client.get_component_status('etcd-0', 'default')

--- a/test/test_endpoint.rb
+++ b/test/test_endpoint.rb
@@ -1,6 +1,9 @@
 require_relative 'test_helper'
 
-# Endpoint entity tests
+# kind: 'Endpoints' entity tests.
+# This is one of the unusual `kind`s that are already plural (https://github.com/kubernetes/kubernetes/issues/8115).
+# We force singular in method names like 'create_endpoint',
+# but `kind` should remain plural as in kubernetes.
 class TestEndpoint < MiniTest::Test
   def test_create_endpoint
     stub_core_api_list
@@ -44,11 +47,8 @@ class TestEndpoint < MiniTest::Test
     assert_equal('EndpointsList', collection[:kind])
     assert_equal('v1', collection[:apiVersion])
 
+    # Stripping of 'List' in collection.kind RecursiveOpenStruct mode only is historic.
     collection = client.get_endpoints
-    # TODO: this is wrong.  https://github.com/abonas/kubeclient/issues/307
-    # Kubernetes for single object uses kind: "Endpoints" (!) and
-    # kind: "EndpointsList" for plural.  While we force singular in method names
-    # to distinguish `get_endpoint` vs `get_endpoints`, we should not touch .kind.
-    assert_equal('Endpoint', collection.kind)
+    assert_equal('Endpoints', collection.kind)
   end
 end

--- a/test/test_endpoint.rb
+++ b/test/test_endpoint.rb
@@ -3,12 +3,7 @@ require_relative 'test_helper'
 # Endpoint entity tests
 class TestEndpoint < MiniTest::Test
   def test_create_endpoint
-    stub_request(:get, %r{/api/v1$})
-      .to_return(
-        body: open_test_file('core_api_resource_list.json'),
-        status: 200
-      )
-
+    stub_core_api_list
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     testing_ep = Kubeclient::Resource.new
     testing_ep.metadata = {}

--- a/test/test_endpoint.rb
+++ b/test/test_endpoint.rb
@@ -4,7 +4,6 @@ require_relative 'test_helper'
 class TestEndpoint < MiniTest::Test
   def test_create_endpoint
     stub_core_api_list
-    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     testing_ep = Kubeclient::Resource.new
     testing_ep.metadata = {}
     testing_ep.metadata.name = 'myendpoint'
@@ -24,7 +23,32 @@ class TestEndpoint < MiniTest::Test
       .with(body: req_body)
       .to_return(body: open_test_file('created_endpoint.json'), status: 201)
 
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     created_ep = client.create_endpoint(testing_ep)
     assert_equal('Endpoints', created_ep.kind)
+    assert_equal('v1', created_ep.apiVersion)
+
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1', as: :parsed_symbolized)
+    created_ep = client.create_endpoint(testing_ep)
+    assert_equal('Endpoints', created_ep[:kind])
+    assert_equal('v1', created_ep[:apiVersion])
+  end
+
+  def test_get_endpoints
+    stub_core_api_list
+    stub_request(:get, %r{/endpoints})
+      .to_return(body: open_test_file('endpoint_list.json'), status: 200)
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+
+    collection = client.get_endpoints(as: :parsed_symbolized)
+    assert_equal('EndpointsList', collection[:kind])
+    assert_equal('v1', collection[:apiVersion])
+
+    collection = client.get_endpoints
+    # TODO: this is wrong.  https://github.com/abonas/kubeclient/issues/307
+    # Kubernetes for single object uses kind: "Endpoints" (!) and
+    # kind: "EndpointsList" for plural.  While we force singular in method names
+    # to distinguish `get_endpoint` vs `get_endpoints`, we should not touch .kind.
+    assert_equal('Endpoint', collection.kind)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,3 +10,8 @@ require 'kubeclient'
 def open_test_file(name)
   File.new(File.join(File.dirname(__FILE__), name.split('.').last, name))
 end
+
+def stub_core_api_list
+  stub_request(:get, %r{/api/v1$})
+    .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
+end

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -208,6 +208,7 @@ class KubeclientTest < MiniTest::Test
 
     refute_empty(services)
     assert_instance_of(Kubeclient::Common::EntityList, services)
+    # Stripping of 'List' in collection.kind RecursiveOpenStruct mode only is historic.
     assert_equal('Service', services.kind)
     assert_equal(2, services.size)
     assert_instance_of(Kubeclient::Resource, services[0])
@@ -234,6 +235,7 @@ class KubeclientTest < MiniTest::Test
 
     response = client.get_services(as: :parsed)
     assert_equal Hash, response.class
+    assert_equal 'ServiceList', response['kind']
     assert_equal %w[metadata spec status], response['items'].first.keys
   end
 
@@ -243,6 +245,7 @@ class KubeclientTest < MiniTest::Test
 
     response = client.get_services(as: :parsed_symbolized)
     assert_equal Hash, response.class
+    assert_equal 'ServiceList', response[:kind]
     assert_equal %i[metadata spec status], response[:items].first.keys
   end
 

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -469,10 +469,7 @@ class KubeclientTest < MiniTest::Test
   end
 
   def test_api_bearer_token_success
-    stub_request(:get, %r{/api/v1$})
-      .to_return(
-        body: open_test_file('core_api_resource_list.json'), status: 200
-      )
+    stub_core_api_list
     stub_request(:get, 'http://localhost:8080/api/v1/pods')
       .with(headers: { Authorization: 'Bearer valid_token' })
       .to_return(
@@ -837,11 +834,6 @@ class KubeclientTest < MiniTest::Test
   def stub_get_services
     stub_request(:get, %r{/services})
       .to_return(body: open_test_file('entity_list.json'), status: 200)
-  end
-
-  def stub_core_api_list
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
   end
 
   def client

--- a/test/test_limit_range.rb
+++ b/test/test_limit_range.rb
@@ -3,9 +3,7 @@ require_relative 'test_helper'
 # LimitRange tests
 class TestLimitRange < MiniTest::Test
   def test_get_from_json_v1
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
-
+    stub_core_api_list
     stub_request(:get, %r{/limitranges})
       .to_return(body: open_test_file('limit_range.json'), status: 200)
 

--- a/test/test_missing_methods.rb
+++ b/test/test_missing_methods.rb
@@ -29,11 +29,30 @@ class TestMissingMethods < MiniTest::Test
     ) # If discovery fails we expect the below raise an exception
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     assert_raises(Kubeclient::HttpError) do
+      client.discover
+    end
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+    assert_raises(Kubeclient::HttpError) do
       client.method(:get_pods)
     end
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     assert_raises(Kubeclient::HttpError) do
       client.respond_to?(:get_pods)
     end
+  end
+
+  def test_irregular_names
+    stub_core_api_list
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+    assert_equal(true, client.respond_to?(:get_endpoint))
+    assert_equal(true, client.respond_to?(:get_endpoints))
+
+    stub_request(:get, %r{/apis/security.openshift.io/v1$}).to_return(
+      body: open_test_file('security.openshift.io_api_resource_list.json'),
+      status: 200
+    )
+    client = Kubeclient::Client.new('http://localhost:8080/apis/security.openshift.io', 'v1')
+    assert_equal(true, client.respond_to?(:get_security_context_constraint))
+    assert_equal(true, client.respond_to?(:get_security_context_constraints))
   end
 end

--- a/test/test_missing_methods.rb
+++ b/test/test_missing_methods.rb
@@ -3,10 +3,7 @@ require_relative 'test_helper'
 # Test method_missing, respond_to? and respond_to_missing behaviour
 class TestMissingMethods < MiniTest::Test
   def test_missing
-    stub_request(:get, %r{/api/v1$}).to_return(
-      body: open_test_file('core_api_resource_list.json'),
-      status: 200
-    )
+    stub_core_api_list
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     assert_equal(true, client.respond_to?(:get_pod))
     assert_equal(true, client.respond_to?(:get_pods))

--- a/test/test_missing_methods.rb
+++ b/test/test_missing_methods.rb
@@ -55,4 +55,14 @@ class TestMissingMethods < MiniTest::Test
     assert_equal(true, client.respond_to?(:get_security_context_constraint))
     assert_equal(true, client.respond_to?(:get_security_context_constraints))
   end
+
+  def test_lowercase_kind
+    stub_request(:get, %r{/apis/config.istio.io/v1alpha2$}).to_return(
+      body: open_test_file('config.istio.io_api_resource_list.json'),
+      status: 200
+    )
+    client = Kubeclient::Client.new('http://localhost:8080/apis/config.istio.io', 'v1alpha2')
+    assert_equal(true, client.respond_to?(:get_servicecontrolreport))
+    assert_equal(true, client.respond_to?(:get_servicecontrolreports))
+  end
 end

--- a/test/test_namespace.rb
+++ b/test/test_namespace.rb
@@ -3,8 +3,7 @@ require_relative 'test_helper'
 # Namespace entity tests
 class TestNamespace < MiniTest::Test
   def test_get_namespace_v1
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
+    stub_core_api_list
     stub_request(:get, %r{/namespaces})
       .to_return(body: open_test_file('namespace.json'), status: 200)
 
@@ -29,8 +28,7 @@ class TestNamespace < MiniTest::Test
     our_namespace.metadata = {}
     our_namespace.metadata.name = 'staging'
 
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
+    stub_core_api_list
     stub_request(:delete, %r{/namespaces})
       .to_return(body: open_test_file('namespace.json'), status: 200)
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
@@ -45,8 +43,7 @@ class TestNamespace < MiniTest::Test
   end
 
   def test_create_namespace
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
+    stub_core_api_list
     stub_request(:post, %r{/namespaces})
       .to_return(body: open_test_file('created_namespace.json'), status: 201)
 

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -3,10 +3,9 @@ require_relative 'test_helper'
 # Node entity tests
 class TestNode < MiniTest::Test
   def test_get_from_json_v1
+    stub_core_api_list
     stub_request(:get, %r{/nodes})
       .to_return(body: open_test_file('node.json'), status: 200)
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     node = client.get_node('127.0.0.1')
@@ -32,10 +31,9 @@ class TestNode < MiniTest::Test
   end
 
   def test_get_from_json_v1_raw
+    stub_core_api_list
     stub_request(:get, %r{/nodes})
       .to_return(body: open_test_file('node.json'), status: 200)
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     response = client.get_node('127.0.0.1', nil, as: :raw)

--- a/test/test_persistent_volume.rb
+++ b/test/test_persistent_volume.rb
@@ -3,10 +3,9 @@ require_relative 'test_helper'
 # PersistentVolume tests
 class TestPersistentVolume < MiniTest::Test
   def test_get_from_json_v1
+    stub_core_api_list
     stub_request(:get, %r{/persistentvolumes})
       .to_return(body: open_test_file('persistent_volume.json'), status: 200)
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     volume = client.get_persistent_volume('pv0001')

--- a/test/test_persistent_volume_claim.rb
+++ b/test/test_persistent_volume_claim.rb
@@ -3,11 +3,9 @@ require_relative 'test_helper'
 # PersistentVolumeClaim tests
 class TestPersistentVolumeClaim < MiniTest::Test
   def test_get_from_json_v1
+    stub_core_api_list
     stub_request(:get, %r{/persistentvolumeclaims})
       .to_return(body: open_test_file('persistent_volume_claim.json'), status: 200)
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
-
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     claim = client.get_persistent_volume_claim('myclaim-1', 'default')
 

--- a/test/test_pod.rb
+++ b/test/test_pod.rb
@@ -3,10 +3,9 @@ require_relative 'test_helper'
 # Pod entity tests
 class TestPod < MiniTest::Test
   def test_get_from_json_v1
+    stub_core_api_list
     stub_request(:get, %r{/pods})
       .to_return(body: open_test_file('pod.json'), status: 200)
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     pod = client.get_pod('redis-master-pod', 'default')
@@ -28,10 +27,9 @@ class TestPod < MiniTest::Test
   end
 
   def test_get_chunks
+    stub_core_api_list
     stub_request(:get, %r{/pods})
       .to_return(body: open_test_file('pods_1.json'), status: 200)
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     pods = client.get_pods(limit: 2)
@@ -66,10 +64,9 @@ class TestPod < MiniTest::Test
   end
 
   def test_get_chunks_410_gone
+    stub_core_api_list
     stub_request(:get, %r{/pods})
       .to_return(body: open_test_file('pods_410.json'), status: 410)
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'), status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
 

--- a/test/test_replication_controller.rb
+++ b/test/test_replication_controller.rb
@@ -3,9 +3,7 @@ require_relative 'test_helper'
 # Replication Controller entity tests
 class TestReplicationController < MiniTest::Test
   def test_get_from_json_v1
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+    stub_core_api_list
     stub_request(:get, %r{/replicationcontrollers})
       .to_return(body: open_test_file('replication_controller.json'),
                  status: 200)
@@ -26,10 +24,7 @@ class TestReplicationController < MiniTest::Test
   end
 
   def test_delete_replicaset_cascade
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
-
+    stub_core_api_list
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     opts = Kubeclient::Resource.new(
       apiVersion: 'meta/v1',

--- a/test/test_resource_quota.rb
+++ b/test/test_resource_quota.rb
@@ -3,9 +3,7 @@ require_relative 'test_helper'
 # ResourceQuota tests
 class TestResourceQuota < MiniTest::Test
   def test_get_from_json_v1
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+    stub_core_api_list
     stub_request(:get, %r{/resourcequotas})
       .to_return(body: open_test_file('resource_quota.json'),
                  status: 200)

--- a/test/test_secret.rb
+++ b/test/test_secret.rb
@@ -3,10 +3,7 @@ require_relative 'test_helper'
 # Namespace entity tests
 class TestSecret < MiniTest::Test
   def test_get_secret_v1
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
-
+    stub_core_api_list
     stub_request(:get, %r{/secrets})
       .to_return(body: open_test_file('created_secret.json'),
                  status: 200)
@@ -26,10 +23,7 @@ class TestSecret < MiniTest::Test
   end
 
   def test_delete_secret_v1
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
-
+    stub_core_api_list
     stub_request(:delete, %r{/secrets})
       .to_return(status: 200, body: open_test_file('created_secret.json'))
 
@@ -43,10 +37,7 @@ class TestSecret < MiniTest::Test
   end
 
   def test_create_secret_v1
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
-
+    stub_core_api_list
     stub_request(:post, %r{/secrets})
       .to_return(body: open_test_file('created_secret.json'),
                  status: 201)

--- a/test/test_security_context_constraint.rb
+++ b/test/test_security_context_constraint.rb
@@ -1,0 +1,66 @@
+require_relative 'test_helper'
+
+# kind: 'SecurityContextConstraints' entity tests.
+# This is one of the unusual `kind`s that are already plural (https://github.com/kubernetes/kubernetes/issues/8115).
+# We force singular in method names like 'create_endpoint',
+# but `kind` should remain plural as in kubernetes.
+class TestSecurityContextConstraints < MiniTest::Test
+  def test_create_security_context_constraint
+    stub_request(:get, %r{/apis/security.openshift.io/v1$}).to_return(
+      body: open_test_file('security.openshift.io_api_resource_list.json'),
+      status: 200
+    )
+
+    testing_scc = Kubeclient::Resource.new(
+      metadata: {
+        name: 'teleportation'
+      },
+      runAsUser: {
+        type: 'MustRunAs'
+      },
+      seLinuxContext: {
+        type: 'MustRunAs'
+      }
+    )
+    # TODO: kind here is wrong, this doesn't work at all!
+    # https://github.com/abonas/kubeclient/issues/367
+    #   SecurityContextConstraint in version "v1" cannot be handled as a SecurityContextConstraints:
+    #   no kind "SecurityContextConstraint" is registered for version "security.openshift.io/v1"
+    req_body = '{"metadata":{"name":"teleportation"},"runAsUser":{"type":"MustRunAs"},' \
+      '"seLinuxContext":{"type":"MustRunAs"},' \
+      '"kind":"SecurityContextConstraint","apiVersion":"security.openshift.io/v1"}'
+
+    stub_request(:post, 'http://localhost:8080/apis/security.openshift.io/v1/securitycontextconstraints')
+      .with(body: req_body)
+      .to_return(body: open_test_file('created_security_context_constraint.json'), status: 201)
+
+    client = Kubeclient::Client.new('http://localhost:8080/apis/security.openshift.io', 'v1')
+    created_scc = client.create_security_context_constraint(testing_scc)
+    assert_equal('SecurityContextConstraints', created_scc.kind)
+    assert_equal('security.openshift.io/v1', created_scc.apiVersion)
+
+    client = Kubeclient::Client.new('http://localhost:8080/apis/security.openshift.io', 'v1',
+                                    as: :parsed_symbolized)
+    created_scc = client.create_security_context_constraint(testing_scc)
+    assert_equal('SecurityContextConstraints', created_scc[:kind])
+    assert_equal('security.openshift.io/v1', created_scc[:apiVersion])
+  end
+
+  def test_get_security_context_constraints
+    stub_request(:get, %r{/apis/security.openshift.io/v1$}).to_return(
+      body: open_test_file('security.openshift.io_api_resource_list.json'),
+      status: 200
+    )
+    stub_request(:get, %r{/securitycontextconstraints})
+      .to_return(body: open_test_file('security_context_constraint_list.json'), status: 200)
+    client = Kubeclient::Client.new('http://localhost:8080/apis/security.openshift.io', 'v1')
+
+    collection = client.get_security_context_constraints(as: :parsed_symbolized)
+    assert_equal('SecurityContextConstraintsList', collection[:kind])
+    assert_equal('security.openshift.io/v1', collection[:apiVersion])
+
+    # TODO: this is wrong.  https://github.com/abonas/kubeclient/issues/307
+    collection = client.get_security_context_constraints
+    assert_equal('SecurityContextConstraint', collection.kind)
+  end
+end

--- a/test/test_security_context_constraint.rb
+++ b/test/test_security_context_constraint.rb
@@ -22,13 +22,9 @@ class TestSecurityContextConstraints < MiniTest::Test
         type: 'MustRunAs'
       }
     )
-    # TODO: kind here is wrong, this doesn't work at all!
-    # https://github.com/abonas/kubeclient/issues/367
-    #   SecurityContextConstraint in version "v1" cannot be handled as a SecurityContextConstraints:
-    #   no kind "SecurityContextConstraint" is registered for version "security.openshift.io/v1"
     req_body = '{"metadata":{"name":"teleportation"},"runAsUser":{"type":"MustRunAs"},' \
       '"seLinuxContext":{"type":"MustRunAs"},' \
-      '"kind":"SecurityContextConstraint","apiVersion":"security.openshift.io/v1"}'
+      '"kind":"SecurityContextConstraints","apiVersion":"security.openshift.io/v1"}'
 
     stub_request(:post, 'http://localhost:8080/apis/security.openshift.io/v1/securitycontextconstraints')
       .with(body: req_body)
@@ -59,8 +55,8 @@ class TestSecurityContextConstraints < MiniTest::Test
     assert_equal('SecurityContextConstraintsList', collection[:kind])
     assert_equal('security.openshift.io/v1', collection[:apiVersion])
 
-    # TODO: this is wrong.  https://github.com/abonas/kubeclient/issues/307
+    # Stripping of 'List' in collection.kind RecursiveOpenStruct mode only is historic.
     collection = client.get_security_context_constraints
-    assert_equal('SecurityContextConstraint', collection.kind)
+    assert_equal('SecurityContextConstraints', collection.kind)
   end
 end

--- a/test/test_service.rb
+++ b/test/test_service.rb
@@ -25,10 +25,7 @@ class TestService < MiniTest::Test
                  hash[:metadata][:labels][:name])
 
     expected_url = 'http://localhost:8080/api/v1/namespaces/staging/services'
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
-
+    stub_core_api_list
     stub_request(:post, expected_url)
       .to_return(body: open_test_file('created_service.json'), status: 201)
 
@@ -67,9 +64,7 @@ class TestService < MiniTest::Test
     }
 
     expected_url = 'http://localhost:8080/api/v1/namespaces/staging/services'
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+    stub_core_api_list
     stub_request(:post, expected_url)
       .to_return(body: open_test_file('created_service.json'), status: 201)
 
@@ -101,9 +96,7 @@ class TestService < MiniTest::Test
       }]
     }
 
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+    stub_core_api_list
     expected_url = 'http://localhost:8080/api/v1/namespaces/staging/services'
     stub_request(:post, %r{namespaces/staging/services})
       .to_return(body: open_test_file('created_service.json'), status: 201)
@@ -122,9 +115,7 @@ class TestService < MiniTest::Test
   end
 
   def test_conversion_from_json_v1
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+    stub_core_api_list
     stub_request(:get, %r{/services})
       .to_return(body: open_test_file('service.json'),
                  status: 200)
@@ -160,9 +151,7 @@ class TestService < MiniTest::Test
     our_service.labels.component = 'apiserver'
     our_service.labels.provider = 'kubernetes'
 
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+    stub_core_api_list
     stub_request(:delete, %r{/namespaces/default/services})
       .to_return(body: open_test_file('service.json'), status: 200)
 
@@ -176,9 +165,7 @@ class TestService < MiniTest::Test
   end
 
   def test_get_service_no_ns
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+    stub_core_api_list
     # when not specifying namespace for entities which
     # are not node or namespace, the request will fail
     stub_request(:get, %r{/services/redis-slave})
@@ -193,9 +180,7 @@ class TestService < MiniTest::Test
   end
 
   def test_get_service
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+    stub_core_api_list
     stub_request(:get, %r{/namespaces/development/services/redis-slave})
       .to_return(body: open_test_file('service.json'),
                  status: 200)
@@ -217,9 +202,7 @@ class TestService < MiniTest::Test
     service.metadata.name      = name
     service.metadata.namespace = 'development'
 
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+    stub_core_api_list
     expected_url = "http://localhost:8080/api/v1/namespaces/development/services/#{name}"
     stub_request(:put, expected_url)
       .to_return(body: open_test_file('service_update.json'), status: 201)
@@ -244,9 +227,7 @@ class TestService < MiniTest::Test
       'namespace' => 'development'
     }
 
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+    stub_core_api_list
     expected_url = "http://localhost:8080/api/v1/namespaces/development/services/#{name}"
     stub_request(:put, expected_url)
       .to_return(body: open_test_file('service_update.json'), status: 201)
@@ -270,9 +251,7 @@ class TestService < MiniTest::Test
     service.metadata.name      = name
     service.metadata.namespace = 'development'
 
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
-                 status: 200)
+    stub_core_api_list
     expected_url = "http://localhost:8080/api/v1/namespaces/development/services/#{name}"
     stub_request(:patch, expected_url)
       .to_return(body: open_test_file('service_patch.json'), status: 200)

--- a/test/test_service_account.rb
+++ b/test/test_service_account.rb
@@ -3,11 +3,9 @@ require_relative 'test_helper'
 # ServiceAccount tests
 class TestServiceAccount < MiniTest::Test
   def test_get_from_json_v1
+    stub_core_api_list
     stub_request(:get, %r{/serviceaccounts})
       .to_return(body: open_test_file('service_account.json'),
-                 status: 200)
-    stub_request(:get, %r{/api/v1$})
-      .to_return(body: open_test_file('core_api_resource_list.json'),
                  status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -3,7 +3,7 @@ require_relative 'test_helper'
 # Watch entity tests
 class TestWatch < MiniTest::Test
   def test_watch_pod_success
-    stub_resource_list
+    stub_core_api_list
 
     expected = [
       { 'type' => 'ADDED', 'resourceVersion' => '1389' },
@@ -28,7 +28,7 @@ class TestWatch < MiniTest::Test
   end
 
   def test_watch_pod_raw
-    stub_resource_list
+    stub_core_api_list
 
     stub_request(:get, %r{/watch/pods}).to_return(
       body: open_test_file('watch_stream.json'),
@@ -43,7 +43,7 @@ class TestWatch < MiniTest::Test
   end
 
   def test_watch_pod_failure
-    stub_resource_list
+    stub_core_api_list
     stub_request(:get, %r{/watch/pods}).to_return(status: 404)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
@@ -72,7 +72,7 @@ class TestWatch < MiniTest::Test
   def test_watch_with_resource_version
     api_host = 'http://localhost:8080/api'
     version = '1995'
-    stub_resource_list
+    stub_core_api_list
     stub_request(:get, %r{.*\/watch/events})
       .to_return(body: open_test_file('watch_stream.json'),
                  status: 200)
@@ -90,7 +90,7 @@ class TestWatch < MiniTest::Test
     api_host = 'http://localhost:8080/api'
     selector = 'name=redis-master'
 
-    stub_resource_list
+    stub_core_api_list
     stub_request(:get, %r{.*\/watch/events})
       .to_return(body: open_test_file('watch_stream.json'),
                  status: 200)
@@ -108,7 +108,7 @@ class TestWatch < MiniTest::Test
     api_host = 'http://localhost:8080/api'
     selector = 'involvedObject.kind=Pod'
 
-    stub_resource_list
+    stub_core_api_list
     stub_request(:get, %r{.*\/watch/events})
       .to_return(body: open_test_file('watch_stream.json'),
                  status: 200)
@@ -125,7 +125,7 @@ class TestWatch < MiniTest::Test
   def test_watch_with_finish_and_ebadf
     api_host = 'http://localhost:8080/api'
 
-    stub_resource_list
+    stub_core_api_list
     stub_request(:get, %r{.*\/watch/events})
       .to_return(body: open_test_file('watch_stream.json'), status: 200)
 
@@ -139,14 +139,5 @@ class TestWatch < MiniTest::Test
     end
 
     assert_requested(:get, "#{api_host}/v1/watch/events", times: 1)
-  end
-
-  private
-
-  def stub_resource_list
-    stub_request(:get, %r{/api/v1$}).to_return(
-      body: open_test_file('core_api_resource_list.json'),
-      status: 200
-    )
   end
 end


### PR DESCRIPTION
Simpler logic, more explicit about intent (e.g. for the 2 special kinds hardcode the final result instead of intermediate step), added explanations.

Also fixes #307 - `get_security_context_constraints.kind`, `get_endpoints.kind` are now plural as in kubernetes.
Also fixes #367 - `create_security_context_constraint` now works.  (tested live too)

Added lots of tests.
 - [x] added changelog.

@f4tq @eatwithforks please review (easier by commits).

After this, I'll rebase #355 and change it to support both new and old names...