### PR TITLE
RELEASING: update how I'm pushing tag

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,7 +55,9 @@ bundle exec rake test rubocop
 
 Create and push the tag:
 ```bash
-gem tag --destination https://github.com/abonas/kubeclient
+gem tag --no-push
+git push --tags --dry-run https://github.com/abonas/kubeclient  # Check for unexpected tags
+git push --tags https://github.com/abonas/kubeclient
 ```
 
 Release onto rubygems.org:


### PR DESCRIPTION
I'm normally working with origin remote (what some call upstream) push url
set to DISABLE so I can't accidentally push to master, only to my fork.
But during release I do need to push the tag.
Plus I prefer writing these instructions to use full URL and not depend
remote naming conventions ("origin" vs "upstream").

`gem tag --destination` no longer exists.
`gem tag --remote origin --push` doesn't work because DISABLE.
So stop relying on `gem tag` to push, use git directly.