### PR TITLE
 Really enforce Config.new(data, nil) prevents external file lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
+## Unreleased
+
+### Security
+- Really made `Kubeclient::Config.new(data, nil)` prevent external file lookups.
+  README documented this since 3.1.1 (#334) but alas that was a lie — absolute paths always worked.
+
 ## 4.1.0 — 2018-11-28
 
 ### Fixed

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -66,6 +66,9 @@ module Kubeclient
     private
 
     def ext_file_path(path)
+      if @kcfg_path.nil?
+        raise "Kubeclient::Config: external lookups disabled, can't load '#{path}'"
+      end
       Pathname(path).absolute? ? path : File.join(@kcfg_path, path)
     end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -28,18 +28,18 @@ class KubeclientConfigTest < MiniTest::Test
     # kcfg_path = nil should prevent file access
     config = Kubeclient::Config.new(YAML.safe_load(yaml), nil)
     assert_raises(StandardError) do
-      config.context.ssl_options
+      config.context
     end
   end
 
   def test_external_nopath_absolute
     yaml = File.read(config_file('external.kubeconfig'))
     # kcfg_path = nil should prevent file access, even if absolute path specified
-    ca_absolute_path = File.absolute_path(config_file('external-ca.pem'))
-    yaml = yaml.gsub('external-ca.pem', ca_absolute_path)
+    ca_absolute_path = File.absolute_path(config_file('external-'))
+    yaml = yaml.gsub('external-', ca_absolute_path)
     config = Kubeclient::Config.new(YAML.safe_load(yaml), nil)
     assert_raises(StandardError) do
-      config.context.ssl_options
+      config.context
     end
   end
 

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -35,7 +35,7 @@ class KubeclientConfigTest < MiniTest::Test
   def test_external_nopath_absolute
     yaml = File.read(config_file('external.kubeconfig'))
     # kcfg_path = nil should prevent file access, even if absolute path specified
-    ca_absolute_path = File.absolute_path(config_file('external.kubeconfig').path)
+    ca_absolute_path = File.absolute_path(config_file('external-ca.pem'))
     yaml = yaml.gsub('external-ca.pem', ca_absolute_path)
     config = Kubeclient::Config.new(YAML.safe_load(yaml), nil)
     assert_raises(StandardError) do
@@ -102,6 +102,6 @@ class KubeclientConfigTest < MiniTest::Test
   end
 
   def config_file(name)
-    File.new(File.join(File.dirname(__FILE__), 'config', name))
+    File.join(File.dirname(__FILE__), 'config', name)
   end
 end


### PR DESCRIPTION
I promised this in README since version 3.1.1 (#334).
Alas that was a lie — absolute path lookups have always worked :flushed: 
(Test passed because 2 of the 3 paths were still relative, so `File.join` raised an error.)

@yaacov @grosser please review