### PR TITLE
Replace '-' with '_' in method names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 
 ## Unreleased
 
+- For resources that contain dashes in name, the generated method names will replace the dash in names with underscores.
+
 ### Security
 - Really made `Kubeclient::Config.new(data, nil)` prevent external file lookups.
   README documented this since 3.1.1 (#334) but alas that was a lie — absolute paths always worked.

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -150,13 +150,19 @@ module Kubeclient
         # But how?  If it differs from kind.downcase, kind's word boundaries don't apply.
         singular_name = kind.downcase
 
-        if name.start_with?(kind.downcase)
+        if name.start_with?(singular_name)
           plural_suffix = name[kind.downcase.length..-1]             # "es"
           singular_underscores = ClientMixin.underscore_entity(kind) # "component_status"
           method_names = [singular_underscores, singular_underscores + plural_suffix]
         else
-          # Something weird, can't infer underscores for plural so just give them up
-          method_names = [singular_name, name]
+          underscored_name = name.tr('-', '_')
+          singular_underscores = ClientMixin.underscore_entity(kind)
+          method_names = if underscored_name.start_with?(singular_underscores)
+                           [singular_underscores, underscored_name]
+                         else
+                           # fallback to lowercase, no separators for both names
+                           [singular_name, underscored_name.tr('_', '')]
+                         end
         end
       end
 

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -74,4 +74,19 @@ class CommonTest < MiniTest::Test
     formatted = client.send(:format_datetime, value)
     assert_equal(formatted, '2018-04-30T19:20:33.000000000+00:00')
   end
+
+  def test_parse_definition_with_unconventional_names
+    %w[
+      TestWithDash test-with-dashes test_with_dash test_with_dashes
+      TestUnderscore test_underscores test_underscore test_underscores
+      TestMismatch other-odd-name testmismatch otheroddname
+      MixedDashMinus mixed-dash_minuses mixed_dash_minus mixed_dash_minuses
+      Noseparator noseparators noseparator noseparators
+      SameUptoWordboundary sameup-toword-boundarys sameuptowordboundary sameuptowordboundarys
+    ].each_slice(4) do |kind, plural, expected_single, expected_plural|
+      method_names = Kubeclient::ClientMixin.parse_definition(kind, plural).method_names
+      assert_equal(method_names[0], expected_single)
+      assert_equal(method_names[1], expected_plural)
+    end
+  end
 end


### PR DESCRIPTION
When names of methods aren't conventional, a minor tweak can allow using
the auto-generated methods.

For instance, the CNI defines entity named `NetworkAttachmentDefinition`.
Its resource is `network-attachment-definition`, and to access the
resource a call should be made for:

`/apis/k8s.cni.cncf.io/v1/namespaces/default/network-attachment-definitions/ovs-foreman`

However, with the current code, the generated methods for that resource
rely on the reported resource definition:

```
{
  "name"=>"network-attachment-definitions",
  "singularName"=>"network-attachment-definition",
  "namespaced"=>true,
  "kind"=>"NetworkAttachmentDefinition",
  "verbs"=>["delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"],
  "shortNames"=>["net-attach-def"]
}
```

And by that, the stored information for the entity looks like:
```
 <OpenStruct entity_type="NetworkAttachmentDefinition",
             resource_name="network-attachment-definitions",
             method_names=["networkattachmentdefinition", "network-attachment-definitions"]>

```
This produces unsupported generated method names such as `get_network-attachment-definitions`
and `watch_network-attachment-definitions` which prevents client to access that resource.

The PR proposes to replace dashes with underscores to allow generation
of legal methods names, regardless of the weird naming.