### PR TITLE
Credential plugins: lookup command relative to config's dir, nil = opt-out

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,5 @@ Security/MarshalLoad:
 Style/MethodCallWithArgsParentheses:
   IgnoredMethods:
   - require_relative
+Style/RegexpLiteral:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 
 ## Unreleased
 
+### Added
+- Support `user: exec: ...` credential plugins like in Go client (#363, #375).
+
 ### Security
-- Really made `Kubeclient::Config.new(data, nil)` prevent external file lookups.
+- Really made `Kubeclient::Config.new(data, nil)` prevent external file lookups. (#372)
   README documented this since 3.1.1 (#334) but alas that was a lie — absolute paths always worked.
+  Now this also prevents credential plugin execution.
+
+  Even in this mode, using config from untrusted sources is not recommended.
 
 ## 4.1.0 — 2018-11-28
 

--- a/test/config/execauth.kubeconfig
+++ b/test/config/execauth.kubeconfig
@@ -8,13 +8,22 @@ contexts:
 - context:
     cluster: localhost:8443
     namespace: default
-    user: system:admin:exec
-  name: localhost/system:admin:exec
-current-context: localhost/system:admin:exec
+    user: system:admin:exec-search-path
+  name: localhost/system:admin:exec-search-path
+- context:
+    cluster: localhost:8443
+    namespace: default
+    user: system:admin:exec-relative-path
+  name: localhost/system:admin:exec-relative-path
+- context:
+    cluster: localhost:8443
+    namespace: default
+    user: system:admin:exec-absolute-path
+  name: localhost/system:admin:exec-absolute-path
 kind: Config
 preferences: {}
 users:
-- name: system:admin:exec
+- name: system:admin:exec-search-path
   user:
     exec:
       # Command to execute. Required.
@@ -38,3 +47,16 @@ users:
       - "arg1"
       - "arg2"
 
+- name: system:admin:exec-relative-path
+  user:
+    exec:
+      # Command to execute. Required.
+      command: "dir/example-exec-plugin"
+      apiVersion: "client.authentication.k8s.io/v1beta1"
+
+- name: system:admin:exec-absolute-path
+  user:
+    exec:
+      # Command to execute. Required.
+      command: "/abs/path/example-exec-plugin"
+      apiVersion: "client.authentication.k8s.io/v1beta1"


### PR DESCRIPTION
Follow-up to #363.

Refine lookup to match [Go client's behavior](https://github.com/kubernetes/kubernetes/pull/59495#discussion_r171138995): Distinguish 3 cases:
- absolute (e.g. `/path/to/foo`)
- `$PATH`-based (e.g. `curl`)
- relative to config file's dir, or specified base dir (e.g. `./foo`)

If base dir explicitly set to nil, refuse to execute external commands, matching existing opt-out from file lookups (#372).

Document security aspects of credential plugins.