### PR TITLE
[v4.1.z] Don't try creating methods for /processedtemplates pseudo-entity

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -516,6 +516,9 @@ module Kubeclient
       @entities = {}
       fetch_entities['resources'].each do |resource|
         next if resource['name'].include?('/')
+        # Not a regular entity, special functionality covered by `process_template`.
+        # https://github.com/openshift/origin/issues/21668
+        next if resource['kind'] == 'Template' && resource['name'] == 'processedtemplates'
         resource['kind'] ||=
           Kubeclient::Common::MissingKindCompatibility.resource_kind(resource['name'])
         entity = ClientMixin.parse_definition(resource['kind'], resource['name'])

--- a/test/json/template.json
+++ b/test/json/template.json
@@ -1,0 +1,27 @@
+{
+    "apiVersion": "template.openshift.io/v1",
+    "kind": "Template",
+    "metadata": {
+        "creationTimestamp": "2018-12-17T16:11:36Z",
+        "name": "my-template",
+        "namespace": "default",
+        "resourceVersion": "21954",
+        "selfLink": "/apis/template.openshift.io/v1/namespaces/default/templates/my-template",
+        "uid": "6e03e3e6-0216-11e9-b1e0-68f728fac3ab"
+    },
+    "objects": [
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": "${NAME_PREFIX}my-service"
+            }
+        }
+    ],
+    "parameters": [
+        {
+            "description": "Prefix for names",
+            "name": "NAME_PREFIX"
+        }
+    ]
+}

--- a/test/json/template.openshift.io_api_resource_list.json
+++ b/test/json/template.openshift.io_api_resource_list.json
@@ -1,0 +1,75 @@
+{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "groupVersion": "template.openshift.io/v1",
+  "resources": [
+    {
+      "name": "brokertemplateinstances",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "BrokerTemplateInstance",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "processedtemplates",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Template",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "templateinstances",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "TemplateInstance",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "templateinstances/status",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "TemplateInstance",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "templates",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Template",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/test/json/template_list.json
+++ b/test/json/template_list.json
@@ -1,0 +1,35 @@
+{
+  "kind": "TemplateList",
+  "apiVersion": "template.openshift.io/v1",
+  "metadata": {
+    "selfLink": "/apis/template.openshift.io/v1/namespaces/default/templates",
+    "resourceVersion": "22758"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "my-template",
+        "namespace": "default",
+        "selfLink": "/apis/template.openshift.io/v1/namespaces/default/templates/my-template",
+        "uid": "6e03e3e6-0216-11e9-b1e0-68f728fac3ab",
+        "resourceVersion": "21954",
+        "creationTimestamp": "2018-12-17T16:11:36Z"
+      },
+      "objects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Service",
+          "metadata": {
+            "name": "${NAME_PREFIX}my-service"
+          }
+        }
+      ],
+      "parameters": [
+        {
+          "name": "NAME_PREFIX",
+          "description": "Prefix for names"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Another small followup for #366, only relevant for openshift.
This changes nothing but achieves the desired result deliberates instead of accidentally :-) :sweat_smile: 

Openshift discovery lists both `templates` and `processedtemplates` paths for same kind "Template": openshift/origin#21668

- `templates` is a regular stored api object.  We want `create_template`, `watch_templates` etc. methods to access this endpoint.
- `processedtemplates` endpoint isn't a stored object, its POST is a special input (template + params) -> output function. That functionality is already covered in kubeclient by `process_template` method.  It doesn't need regular `create_`, `get_` etc methods.

Before 4.1.0, `processedtemplates` was discarded in `parse_definition` as it didn't match the singular kind.  
AFAICT it's still not a problem because first we collect `@entities` hash keyed by singular name, and all openshift discovery data, `templates` comes *after* `processedtemplates` and replaces it in `@entities["template"]`.  So no `processedtemplates`  methods were defined :laughing: 
Anyway, this patch avoids the collision by explicitly skipping `processedtemplates`.

@masayag @grosser please review