### PR TITLE
Release 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
-## Unreleased
+## 4.1.1 — 2018-12-17
 
 ### Fixed
 

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -1,4 +1,4 @@
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '4.1.0'.freeze
+  VERSION = '4.1.1'.freeze
 end


### PR DESCRIPTION
Releasing from a branch, not master.  Will forward-port these to master as well.

- #377 fixes regression (#376) in 4.1.0.
- #378 afaict changes nothing, but achieves the desired result deliberates instead of accidentally — no changelog needed.