### PR TITLE
Forward-port changes from 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 - Really made `Kubeclient::Config.new(data, nil)` prevent external file lookups.
   README documented this since 3.1.1 (#334) but alas that was a lie — absolute paths always worked.
 
-## 4.1.0 — 2018-11-28
+## 4.1.1 — 2018-12-17
+
+### Fixed
+
+- Fixed method names for non-suffix plurals such as y -> ies  (#377).
+
+## 4.1.0 — 2018-11-28 — REGRESSION
+
+This version broke method names where plural is not just adding a suffix, notably y -> ies (bug #376).
 
 ### Fixed
 - Support custom resources with lowercase `kind` (#361).
@@ -39,7 +47,7 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 
 ## 3.1.1 - 2018-06-01 — REGRESSION
 
-In this version `Kubeclient::Config.read` raises Psych::DisallowedClass on legal yaml configs containing a timestamp, for example gcp access-token expiry (#337).
+In this version `Kubeclient::Config.read` raises Psych::DisallowedClass on legal yaml configs containing a timestamp, for example gcp access-token expiry (bug #337).
 
 ### Security
 - Changed `Kubeclient::Config.read` to use `YAML.safe_load` (#334).

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -1,4 +1,4 @@
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '4.1.0'.freeze
+  VERSION = '4.1.1'.freeze
 end

--- a/test/json/extensions_v1beta1_api_resource_list.json
+++ b/test/json/extensions_v1beta1_api_resource_list.json
@@ -1,0 +1,217 @@
+{
+  "kind": "APIResourceList",
+  "groupVersion": "extensions/v1beta1",
+  "resources": [
+    {
+      "name": "daemonsets",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "DaemonSet",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "ds"
+      ]
+    },
+    {
+      "name": "daemonsets/status",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "DaemonSet",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "deployments",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Deployment",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "deploy"
+      ]
+    },
+    {
+      "name": "deployments/rollback",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "DeploymentRollback",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "deployments/scale",
+      "singularName": "",
+      "namespaced": true,
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "deployments/status",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Deployment",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "ingresses",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Ingress",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "ing"
+      ]
+    },
+    {
+      "name": "ingresses/status",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Ingress",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "networkpolicies",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "NetworkPolicy",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "netpol"
+      ]
+    },
+    {
+      "name": "podsecuritypolicies",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "PodSecurityPolicy",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "psp"
+      ]
+    },
+    {
+      "name": "replicasets",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "ReplicaSet",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ],
+      "shortNames": [
+        "rs"
+      ]
+    },
+    {
+      "name": "replicasets/scale",
+      "singularName": "",
+      "namespaced": true,
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "replicasets/status",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "ReplicaSet",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "replicationcontrollers",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "ReplicationControllerDummy",
+      "verbs": []
+    },
+    {
+      "name": "replicationcontrollers/scale",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Scale",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    }
+  ]
+}

--- a/test/json/template.json
+++ b/test/json/template.json
@@ -1,0 +1,27 @@
+{
+    "apiVersion": "template.openshift.io/v1",
+    "kind": "Template",
+    "metadata": {
+        "creationTimestamp": "2018-12-17T16:11:36Z",
+        "name": "my-template",
+        "namespace": "default",
+        "resourceVersion": "21954",
+        "selfLink": "/apis/template.openshift.io/v1/namespaces/default/templates/my-template",
+        "uid": "6e03e3e6-0216-11e9-b1e0-68f728fac3ab"
+    },
+    "objects": [
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": "${NAME_PREFIX}my-service"
+            }
+        }
+    ],
+    "parameters": [
+        {
+            "description": "Prefix for names",
+            "name": "NAME_PREFIX"
+        }
+    ]
+}

--- a/test/json/template.openshift.io_api_resource_list.json
+++ b/test/json/template.openshift.io_api_resource_list.json
@@ -1,0 +1,75 @@
+{
+  "kind": "APIResourceList",
+  "apiVersion": "v1",
+  "groupVersion": "template.openshift.io/v1",
+  "resources": [
+    {
+      "name": "brokertemplateinstances",
+      "singularName": "",
+      "namespaced": false,
+      "kind": "BrokerTemplateInstance",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "processedtemplates",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Template",
+      "verbs": [
+        "create"
+      ]
+    },
+    {
+      "name": "templateinstances",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "TemplateInstance",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    },
+    {
+      "name": "templateinstances/status",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "TemplateInstance",
+      "verbs": [
+        "get",
+        "patch",
+        "update"
+      ]
+    },
+    {
+      "name": "templates",
+      "singularName": "",
+      "namespaced": true,
+      "kind": "Template",
+      "verbs": [
+        "create",
+        "delete",
+        "deletecollection",
+        "get",
+        "list",
+        "patch",
+        "update",
+        "watch"
+      ]
+    }
+  ]
+}

--- a/test/json/template_list.json
+++ b/test/json/template_list.json
@@ -1,0 +1,35 @@
+{
+  "kind": "TemplateList",
+  "apiVersion": "template.openshift.io/v1",
+  "metadata": {
+    "selfLink": "/apis/template.openshift.io/v1/namespaces/default/templates",
+    "resourceVersion": "22758"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "my-template",
+        "namespace": "default",
+        "selfLink": "/apis/template.openshift.io/v1/namespaces/default/templates/my-template",
+        "uid": "6e03e3e6-0216-11e9-b1e0-68f728fac3ab",
+        "resourceVersion": "21954",
+        "creationTimestamp": "2018-12-17T16:11:36Z"
+      },
+      "objects": [
+        {
+          "apiVersion": "v1",
+          "kind": "Service",
+          "metadata": {
+            "name": "${NAME_PREFIX}my-service"
+          }
+        }
+      ],
+      "parameters": [
+        {
+          "name": "NAME_PREFIX",
+          "description": "Prefix for names"
+        }
+      ]
+    }
+  ]
+}

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -74,4 +74,17 @@ class CommonTest < MiniTest::Test
     formatted = client.send(:format_datetime, value)
     assert_equal(formatted, '2018-04-30T19:20:33.000000000+00:00')
   end
+
+  def test_parse_definition_with_unconventional_names
+    %w[
+      PluralPolicy pluralpolicies plural_policy plural_policies
+      LatinDatum latindata latin_datum latin_data
+      Noseparator noseparators noseparator noseparators
+      lowercase lowercases lowercase lowercases
+    ].each_slice(4) do |kind, plural, expected_single, expected_plural|
+      method_names = Kubeclient::ClientMixin.parse_definition(kind, plural).method_names
+      assert_equal(method_names[0], expected_single)
+      assert_equal(method_names[1], expected_plural)
+    end
+  end
 end

--- a/test/test_missing_methods.rb
+++ b/test/test_missing_methods.rb
@@ -41,6 +41,18 @@ class TestMissingMethods < MiniTest::Test
     end
   end
 
+  def test_nonsuffix_plurals
+    stub_request(:get, %r{/apis/extensions/v1beta1$}).to_return(
+      body: open_test_file('extensions_v1beta1_api_resource_list.json'),
+      status: 200
+    )
+    client = Kubeclient::Client.new('http://localhost:8080/apis/extensions', 'v1beta1')
+    assert_equal(true, client.respond_to?(:get_network_policy))
+    assert_equal(true, client.respond_to?(:get_network_policies))
+    assert_equal(true, client.respond_to?(:get_pod_security_policy))
+    assert_equal(true, client.respond_to?(:get_pod_security_policies))
+  end
+
   def test_irregular_names
     stub_core_api_list
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')


### PR DESCRIPTION
Merge #377 and #378 (and the release itself #379) back into master.

My idea for `v4.1.z` branch was treating the bug in 4.1.0 as "interrupt", put changes on master and some open PRs aside, release 4.1.1, then pretend 4.1.1 happened *before* these PRs.
Since the changelog for 4.1.1 is also relevant for future releases (next is probably 4.2.0), I can just merge it all to master.

@masayag this is what I meant saying you'll get merge conflicts in your #373.  Do you object?
An alternative would be merging #373 to master first, then forward-porting these, but then the y -> ies fix would need merge conflict, and would exist in 2 forms on v4.1.z vs master; I prefer having same change across branches, where possible.

In any case we need to combine #373 with the correct logic supporting y -> ies; I'm happy to help.