### PR TITLE
Fallback to lower-case method names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+- For resources that contain dashes in name, there will be an attempt to resolve the method name based on singular name prefix or by replacing the dash in names with underscores.
+
 ## 4.2.0 — 2018-12-20
 
 ### Added
@@ -19,7 +24,6 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 ## 4.1.1 — 2018-12-17
 
 ### Fixed
-
 - Fixed method names for non-suffix plurals such as y -> ies  (#377).
 
 ## 4.1.0 — 2018-11-28 — REGRESSION

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -163,8 +163,7 @@ module Kubeclient
             method_names = [prefix_underscores + singular_suffix,      # "network_policy"
                             prefix_underscores + plural_suffix]        # "network_policies"
           else
-            # Something weird, can't infer underscores for plural so just give them up
-            method_names = [singular_name, name]
+            method_names = resolve_unconventional_method_names(name, kind, singular_name)
           end
         end
       end
@@ -174,6 +173,17 @@ module Kubeclient
         resource_name: name,
         method_names:  method_names
       )
+    end
+
+    def self.resolve_unconventional_method_names(name, kind, singular_name)
+      underscored_name = name.tr('-', '_')
+      singular_underscores = ClientMixin.underscore_entity(kind)
+      if underscored_name.start_with?(singular_underscores)
+        [singular_underscores, underscored_name]
+      else
+        # fallback to lowercase, no separators for both names
+        [singular_name, underscored_name.tr('_', '')]
+      end
     end
 
     def handle_uri(uri, path)

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -81,6 +81,11 @@ class CommonTest < MiniTest::Test
       LatinDatum latindata latin_datum latin_data
       Noseparator noseparators noseparator noseparators
       lowercase lowercases lowercase lowercases
+      TestWithDash test-with-dashes test_with_dash test_with_dashes
+      TestUnderscore test_underscores test_underscore test_underscores
+      TestMismatch other-odd-name testmismatch otheroddname
+      MixedDashMinus mixed-dash_minuses mixed_dash_minus mixed_dash_minuses
+      SameUptoWordboundary sameup-toword-boundarys sameuptowordboundary sameuptowordboundarys
     ].each_slice(4) do |kind, plural, expected_single, expected_plural|
       method_names = Kubeclient::ClientMixin.parse_definition(kind, plural).method_names
       assert_equal(method_names[0], expected_single)


### PR DESCRIPTION
When names of methods aren't conventional, there will be an attempt to
produce method names based on the following logic:

1. If the plural name without separators starts with lower-cased 'kind',
   use underscores as separators (assuming plural has separators)
2. In case of a mismatch, remove any separators and plural name will be
   the lower-case of it.

For instance, the CNI defines entity named NetworkAttachmentDefinition.
Its resource is 'network-attachment-definition', so to access the
resource a call should be made for:

/apis/k8s.cni.cncf.io/v1/namespaces/default/network-attachment-definitions

However, with the current code, the generated methods for that resource
rely on the reported resource definition:

{
  "name"=>"network-attachment-definitions",
  "singularName"=>"network-attachment-definition",
  "namespaced"=>true,
  "kind"=>"NetworkAttachmentDefinition",
  "verbs"=>["delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"],
  "shortNames"=>["net-attach-def"]
}

And by that, the stored information for the entity looks like:
 <OpenStruct entity_type="NetworkAttachmentDefinition",
             resource_name="network-attachment-definitions",
             method_names=["networkattachmentdefinition", "network-attachment-definitions"]>

This produces unsupported generated method names such as 'get_network-attachment-definitions'
and 'watch_network-attachment-definitions' which prevents client to access that resource.

Using the PR, the generated method names will be:
'get_network_attachment_definition' and 'get_network_definitions'.