### PR TITLE
Release 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
-## Unreleased
+## 4.2.1 — 2018-12-26
 
 ### Fixed
-- For resources that contain dashes in name, there will be an attempt to resolve the method name based on singular name prefix or by replacing the dash in names with underscores.
+- For resources that contain dashes in name, there will be an attempt to resolve the method name based on singular name prefix or by replacing the dash in names with underscores (#383).
 
 ## 4.2.0 — 2018-12-20
 
@@ -20,6 +20,13 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
   Now this also prevents credential plugin execution.
 
   Even in this mode, using config from untrusted sources is not recommended.
+
+This release included all changes up to 4.1.1, but NOT 4.1.2 which was branched off later (4.2.1 does include same fix).
+
+## 4.1.2 — 2018-12-26
+
+### Fixed
+- For resources that contain dashes in name, there will be an attempt to resolve the method name based on singular name prefix or by replacing the dash in names with underscores (#382).
 
 ## 4.1.1 — 2018-12-17
 

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -1,4 +1,4 @@
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '4.2.0'.freeze
+  VERSION = '4.2.1'.freeze
 end


### PR DESCRIPTION
I want CHANGELOG at least on master to include all known releases.
Mostly the changelog can pretend all semver version belong to a single linear cumulative history, but not in this case. Tried to explain the graph, which in _simplified_ conceptual form is:
```
●─╮ 4.2.1
│ ⍿ 4.1.2
⍿ │ 4.2.0
⍿─╯ 4.1.1
⍿   4.1.0
```

cc @masayag 