### PR TITLE
Positional and params support

### DIFF
--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -413,8 +413,8 @@ module Kubeclient
     def get_pod_log(pod_name = nil, namespace = nil, container: nil, **opts)
       params = {}
       params[:container] = container if container
-      params[:previous] = true if opts[:previous]
-      params[:timestamps] = opts[:timestamps] if opts[:timestamps]
+      params[:previous] = opts.include?(:previous)
+      params[:timestamps] = opts.include?(:timestamps)
       params[:sinceTime] = format_datetime(opts[:since_time]) if opts[:since_time]
       params[:tailLines] = opts[:tail_lines] if opts[:tail_lines]
 

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -413,8 +413,8 @@ module Kubeclient
     def get_pod_log(pod_name = nil, namespace = nil, container: nil, **opts)
       params = {}
       params[:container] = container if container
-      params[:previous] = opts.include?(:previous)
-      params[:timestamps] = opts.include?(:timestamps)
+      params[:previous] = true if opts[:previous]
+      params[:timestamps] = opts[:timestamps] if opts[:timestamps]
       params[:sinceTime] = format_datetime(opts[:since_time]) if opts[:since_time]
       params[:tailLines] = opts[:tail_lines] if opts[:tail_lines]
 

--- a/test/cassettes/kubernetes_guestbook.yml
+++ b/test/cassettes/kubernetes_guestbook.yml
@@ -1,851 +1,8 @@
 ---
 http_interactions:
 - request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '253'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Failure",
-          "message": "namespaces \"kubeclient-ns\" not found",
-          "reason": "NotFound",
-          "details": {
-            "name": "kubeclient-ns",
-            "kind": "namespaces"
-          },
-          "code": 404
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/services/guestbook
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '239'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Failure",
-          "message": "service \"guestbook\" not found",
-          "reason": "NotFound",
-          "details": {
-            "name": "guestbook",
-            "kind": "service"
-          },
-          "code": 404
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/services/redis-master
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '245'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Failure",
-          "message": "service \"redis-master\" not found",
-          "reason": "NotFound",
-          "details": {
-            "name": "redis-master",
-            "kind": "service"
-          },
-          "code": 404
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/services/redis-slave
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '243'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Failure",
-          "message": "service \"redis-slave\" not found",
-          "reason": "NotFound",
-          "details": {
-            "name": "redis-slave",
-            "kind": "service"
-          },
-          "code": 404
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '269'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Failure",
-          "message": "replicationControllers \"guestbook\" not found",
-          "reason": "NotFound",
-          "details": {
-            "name": "guestbook",
-            "kind": "replicationControllers"
-          },
-          "code": 404
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '275'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Failure",
-          "message": "replicationControllers \"redis-master\" not found",
-          "reason": "NotFound",
-          "details": {
-            "name": "redis-master",
-            "kind": "replicationControllers"
-          },
-          "code": 404
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '273'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Failure",
-          "message": "replicationControllers \"redis-slave\" not found",
-          "reason": "NotFound",
-          "details": {
-            "name": "redis-slave",
-            "kind": "replicationControllers"
-          },
-          "code": 404
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: post
-    uri: http://10.35.0.23:8080/api/v1/namespaces
-    body:
-      encoding: UTF-8
-      string: '{"metadata":{"name":"kubeclient-ns"},"kind":"Namespace","apiVersion":"v1"}'
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '74'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '297'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"f41e6b27-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"534","creationTimestamp":"2015-08-09T10:03:59Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}'
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: post
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/services
-    body:
-      encoding: UTF-8
-      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"name":"guestbook"},"name":"guestbook"},"spec":{"selector":{"app":"guestbook"},"ports":[{"port":3000,"targetPort":"http-server"}]},"type":"LoadBalancer","kind":"Service","apiVersion":"v1"}'
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '239'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '521'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/guestbook","uid":"f42187e1-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"538","creationTimestamp":"2015-08-09T10:03:59Z","labels":{"name":"guestbook"}},"spec":{"ports":[{"protocol":"TCP","port":3000,"targetPort":"http-server","nodePort":0}],"selector":{"app":"guestbook"},"clusterIP":"10.0.0.80","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}'
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: post
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/services
-    body:
-      encoding: UTF-8
-      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"master"},"name":"redis-master"},"spec":{"selector":{"app":"redis","role":"master"},"ports":[{"port":6379,"targetPort":"redis-server"}]},"kind":"Service","apiVersion":"v1"}'
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '244'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '552'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-master","uid":"f423bf8b-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"542","creationTimestamp":"2015-08-09T10:03:59Z","labels":{"app":"redis","role":"master"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server","nodePort":0}],"selector":{"app":"redis","role":"master"},"clusterIP":"10.0.0.140","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}'
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: post
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/services
-    body:
-      encoding: UTF-8
-      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"slave"},"name":"redis-slave"},"spec":{"selector":{"app":"redis","role":"slave"},"ports":[{"port":6379,"targetPort":"redis-server"}]},"kind":"Service","apiVersion":"v1"}'
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '241'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '548'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-slave","uid":"f4264678-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"545","creationTimestamp":"2015-08-09T10:03:59Z","labels":{"app":"redis","role":"slave"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server","nodePort":0}],"selector":{"app":"redis","role":"slave"},"clusterIP":"10.0.0.154","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}'
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: post
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/replicationcontrollers
-    body:
-      encoding: UTF-8
-      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"guestbook","role":"slave"},"name":"guestbook"},"spec":{"selector":{"app":"guestbook"},"template":{"metadata":{"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000}]}]}},"replicas":3},"kind":"ReplicationController","apiVersion":"v1"}'
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '395'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '815'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"f4287784-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"547","generation":1,"creationTimestamp":"2015-08-09T10:03:59Z","labels":{"app":"guestbook","role":"slave"}},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"ClusterFirst"}}},"status":{"replicas":0}}'
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: post
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/replicationcontrollers
-    body:
-      encoding: UTF-8
-      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"master"},"name":"redis-master"},"spec":{"selector":{"app":"redis","role":"master"},"template":{"metadata":{"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379}]}]}},"replicas":1},"kind":"ReplicationController","apiVersion":"v1"}'
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '405'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '828'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"f42a9800-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"558","generation":1,"creationTimestamp":"2015-08-09T10:03:59Z","labels":{"app":"redis","role":"master"}},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"ClusterFirst"}}},"status":{"replicas":0}}'
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: post
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/replicationcontrollers
-    body:
-      encoding: UTF-8
-      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"slave"},"name":"redis-slave"},"spec":{"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379}]}]}},"replicas":2},"kind":"ReplicationController","apiVersion":"v1"}'
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Length:
-      - '420'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '842'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"f42e1d09-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"567","generation":1,"creationTimestamp":"2015-08-09T10:03:59Z","labels":{"app":"redis","role":"slave"}},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"ClusterFirst"}}},"status":{"replicas":0}}'
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
     method: get
-    uri: http://10.35.0.23:8080/api/v1/namespaces
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '629'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"NamespaceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces","resourceVersion":"570"},"items":[{"metadata":{"name":"default","selfLink":"/api/v1/namespaces/default","uid":"37360c82-3e77-11e5-a75a-18037327aaeb","resourceVersion":"6","creationTimestamp":"2015-08-09T09:15:45Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"f41e6b27-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"534","creationTimestamp":"2015-08-09T10:03:59Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}]}'
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: get
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/services
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '1661'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"ServiceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/kubeclient-ns/services","resourceVersion":"571"},"items":[{"metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/guestbook","uid":"f42187e1-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"538","creationTimestamp":"2015-08-09T10:03:59Z","labels":{"name":"guestbook"}},"spec":{"ports":[{"protocol":"TCP","port":3000,"targetPort":"http-server","nodePort":0}],"selector":{"app":"guestbook"},"clusterIP":"10.0.0.80","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}},{"metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-master","uid":"f423bf8b-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"542","creationTimestamp":"2015-08-09T10:03:59Z","labels":{"app":"redis","role":"master"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server","nodePort":0}],"selector":{"app":"redis","role":"master"},"clusterIP":"10.0.0.140","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}},{"metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-slave","uid":"f4264678-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"545","creationTimestamp":"2015-08-09T10:03:59Z","labels":{"app":"redis","role":"slave"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server","nodePort":0}],"selector":{"app":"redis","role":"slave"},"clusterIP":"10.0.0.154","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}]}'
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: get
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/replicationcontrollers
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: '{"kind":"ReplicationControllerList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers","resourceVersion":"571"},"items":[{"metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"f4287784-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"557","generation":1,"creationTimestamp":"2015-08-09T10:03:59Z","labels":{"app":"guestbook","role":"slave"}},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"ClusterFirst"}}},"status":{"replicas":3,"observedGeneration":1}},{"metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"f42a9800-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"565","generation":1,"creationTimestamp":"2015-08-09T10:03:59Z","labels":{"app":"redis","role":"master"}},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"ClusterFirst"}}},"status":{"replicas":0,"observedGeneration":1}},{"metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"f42e1d09-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"567","generation":1,"creationTimestamp":"2015-08-09T10:03:59Z","labels":{"app":"redis","role":"slave"}},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","dnsPolicy":"ClusterFirst"}}},"status":{"replicas":0}}]}'
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/services/guestbook
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '100'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Success",
-          "code": 200
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/services/redis-master
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '100'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Success",
-          "code": 200
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/services/redis-slave
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '100'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Success",
-          "code": 200
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '100'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Success",
-          "code": 200
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '100'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Success",
-          "code": 200
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '100'
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "kind": "Status",
-          "apiVersion": "v1",
-          "metadata": {},
-          "status": "Success",
-          "code": 200
-        }
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: delete
-    uri: http://10.35.0.23:8080/api/v1/namespaces/kubeclient-ns
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - '*/*; q=0.5, application/xml'
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json
-      Date:
-      - Sun, 09 Aug 2015 10:03:59 GMT
-      Content-Length:
-      - '345'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"f41e6b27-3e7d-11e5-a75a-18037327aaeb","resourceVersion":"584","creationTimestamp":"2015-08-09T10:03:59Z","deletionTimestamp":"2015-08-09T10:03:59Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Terminating"}}'
-    http_version: 
-  recorded_at: Sun, 09 Aug 2015 10:00:02 GMT
-- request:
-    method: get
-    uri: http://10.35.0.23:8080/api/v1
+    uri: https://fake.host.com:8443/api/v1
     body:
       encoding: US-ASCII
       string: ''
@@ -855,9 +12,9 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.0p0
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
       Host:
-      - localhost:8080
+      - fake.host.com:8443
   response:
     status:
       code: 200
@@ -866,14 +23,869 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 29 Aug 2016 15:51:30 GMT
+      - Sat, 26 Jan 2019 06:21:57 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"kind":"APIResourceList","groupVersion":"v1","resources":[{"name":"bindings","namespaced":true,"kind":"Binding"},{"name":"componentstatuses","namespaced":false,"kind":"ComponentStatus"},{"name":"configmaps","namespaced":true,"kind":"ConfigMap"},{"name":"endpoints","namespaced":true,"kind":"Endpoints"},{"name":"events","namespaced":true,"kind":"Event"},{"name":"limitranges","namespaced":true,"kind":"LimitRange"},{"name":"namespaces","namespaced":false,"kind":"Namespace"},{"name":"namespaces/finalize","namespaced":false,"kind":"Namespace"},{"name":"namespaces/status","namespaced":false,"kind":"Namespace"},{"name":"nodes","namespaced":false,"kind":"Node"},{"name":"nodes/proxy","namespaced":false,"kind":"Node"},{"name":"nodes/status","namespaced":false,"kind":"Node"},{"name":"persistentvolumeclaims","namespaced":true,"kind":"PersistentVolumeClaim"},{"name":"persistentvolumeclaims/status","namespaced":true,"kind":"PersistentVolumeClaim"},{"name":"persistentvolumes","namespaced":false,"kind":"PersistentVolume"},{"name":"persistentvolumes/status","namespaced":false,"kind":"PersistentVolume"},{"name":"pods","namespaced":true,"kind":"Pod"},{"name":"pods/attach","namespaced":true,"kind":"Pod"},{"name":"pods/binding","namespaced":true,"kind":"Binding"},{"name":"pods/exec","namespaced":true,"kind":"Pod"},{"name":"pods/log","namespaced":true,"kind":"Pod"},{"name":"pods/portforward","namespaced":true,"kind":"Pod"},{"name":"pods/proxy","namespaced":true,"kind":"Pod"},{"name":"pods/status","namespaced":true,"kind":"Pod"},{"name":"podtemplates","namespaced":true,"kind":"PodTemplate"},{"name":"replicationcontrollers","namespaced":true,"kind":"ReplicationController"},{"name":"replicationcontrollers/scale","namespaced":true,"kind":"Scale"},{"name":"replicationcontrollers/status","namespaced":true,"kind":"ReplicationController"},{"name":"resourcequotas","namespaced":true,"kind":"ResourceQuota"},{"name":"resourcequotas/status","namespaced":true,"kind":"ResourceQuota"},{"name":"secrets","namespaced":true,"kind":"Secret"},{"name":"serviceaccounts","namespaced":true,"kind":"ServiceAccount"},{"name":"services","namespaced":true,"kind":"Service"},{"name":"services/proxy","namespaced":true,"kind":"Service"},{"name":"services/status","namespaced":true,"kind":"Service"}]}
+      string: '{"kind":"APIResourceList","groupVersion":"v1","resources":[{"name":"bindings","singularName":"","namespaced":true,"kind":"Binding","verbs":["create"]},{"name":"componentstatuses","singularName":"","namespaced":false,"kind":"ComponentStatus","verbs":["get","list"],"shortNames":["cs"]},{"name":"configmaps","singularName":"","namespaced":true,"kind":"ConfigMap","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["cm"]},{"name":"endpoints","singularName":"","namespaced":true,"kind":"Endpoints","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ep"]},{"name":"events","singularName":"","namespaced":true,"kind":"Event","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ev"]},{"name":"limitranges","singularName":"","namespaced":true,"kind":"LimitRange","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["limits"]},{"name":"namespaces","singularName":"","namespaced":false,"kind":"Namespace","verbs":["create","delete","get","list","patch","update","watch"],"shortNames":["ns"]},{"name":"namespaces/finalize","singularName":"","namespaced":false,"kind":"Namespace","verbs":["update"]},{"name":"namespaces/status","singularName":"","namespaced":false,"kind":"Namespace","verbs":["get","patch","update"]},{"name":"nodes","singularName":"","namespaced":false,"kind":"Node","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["no"]},{"name":"nodes/proxy","singularName":"","namespaced":false,"kind":"Node","verbs":[]},{"name":"nodes/status","singularName":"","namespaced":false,"kind":"Node","verbs":["get","patch","update"]},{"name":"persistentvolumeclaims","singularName":"","namespaced":true,"kind":"PersistentVolumeClaim","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pvc"]},{"name":"persistentvolumeclaims/status","singularName":"","namespaced":true,"kind":"PersistentVolumeClaim","verbs":["get","patch","update"]},{"name":"persistentvolumes","singularName":"","namespaced":false,"kind":"PersistentVolume","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pv"]},{"name":"persistentvolumes/status","singularName":"","namespaced":false,"kind":"PersistentVolume","verbs":["get","patch","update"]},{"name":"pods","singularName":"","namespaced":true,"kind":"Pod","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["po"],"categories":["all"]},{"name":"pods/attach","singularName":"","namespaced":true,"kind":"Pod","verbs":[]},{"name":"pods/binding","singularName":"","namespaced":true,"kind":"Binding","verbs":["create"]},{"name":"pods/eviction","singularName":"","namespaced":true,"group":"policy","version":"v1beta1","kind":"Eviction","verbs":["create"]},{"name":"pods/exec","singularName":"","namespaced":true,"kind":"Pod","verbs":[]},{"name":"pods/log","singularName":"","namespaced":true,"kind":"Pod","verbs":["get"]},{"name":"pods/portforward","singularName":"","namespaced":true,"kind":"Pod","verbs":[]},{"name":"pods/proxy","singularName":"","namespaced":true,"kind":"Pod","verbs":[]},{"name":"pods/status","singularName":"","namespaced":true,"kind":"Pod","verbs":["get","patch","update"]},{"name":"podtemplates","singularName":"","namespaced":true,"kind":"PodTemplate","verbs":["create","delete","deletecollection","get","list","patch","update","watch"]},{"name":"replicationcontrollers","singularName":"","namespaced":true,"kind":"ReplicationController","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["rc"],"categories":["all"]},{"name":"replicationcontrollers/scale","singularName":"","namespaced":true,"group":"autoscaling","version":"v1","kind":"Scale","verbs":["get","patch","update"]},{"name":"replicationcontrollers/status","singularName":"","namespaced":true,"kind":"ReplicationController","verbs":["get","patch","update"]},{"name":"resourcequotas","singularName":"","namespaced":true,"kind":"ResourceQuota","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["quota"]},{"name":"resourcequotas/status","singularName":"","namespaced":true,"kind":"ResourceQuota","verbs":["get","patch","update"]},{"name":"secrets","singularName":"","namespaced":true,"kind":"Secret","verbs":["create","delete","deletecollection","get","list","patch","update","watch"]},{"name":"serviceaccounts","singularName":"","namespaced":true,"kind":"ServiceAccount","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["sa"]},{"name":"services","singularName":"","namespaced":true,"kind":"Service","verbs":["create","delete","get","list","patch","update","watch"],"shortNames":["svc"],"categories":["all"]},{"name":"services/proxy","singularName":"","namespaced":true,"kind":"Service","verbs":[]},{"name":"services/status","singularName":"","namespaced":true,"kind":"Service","verbs":["get","patch","update"]}]}
 
 '
     http_version: 
-  recorded_at: Mon, 29 Aug 2016 15:51:30 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Sat, 26 Jan 2019 06:21:55 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '206'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"namespaces
+        \"kubeclient-ns\" not found","reason":"NotFound","details":{"name":"kubeclient-ns","kind":"namespaces"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:55 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services/guestbook
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '194'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"services
+        \"guestbook\" not found","reason":"NotFound","details":{"name":"guestbook","kind":"services"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services/redis-master
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '200'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"services
+        \"redis-master\" not found","reason":"NotFound","details":{"name":"redis-master","kind":"services"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services/redis-slave
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '198'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"services
+        \"redis-slave\" not found","reason":"NotFound","details":{"name":"redis-slave","kind":"services"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '222'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"replicationcontrollers
+        \"guestbook\" not found","reason":"NotFound","details":{"name":"guestbook","kind":"replicationcontrollers"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '228'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"replicationcontrollers
+        \"redis-master\" not found","reason":"NotFound","details":{"name":"redis-master","kind":"replicationcontrollers"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '226'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"replicationcontrollers
+        \"redis-slave\" not found","reason":"NotFound","details":{"name":"redis-slave","kind":"replicationcontrollers"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: post
+    uri: https://fake.host.com:8443/api/v1/namespaces
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"name":"kubeclient-ns"},"kind":"Namespace","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '74'
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"aeac5431-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4766","creationTimestamp":"2019-01-26T06:21:57Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: post
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"name":"guestbook"},"name":"guestbook"},"spec":{"selector":{"app":"guestbook"},"ports":[{"port":3000,"targetPort":"http-server"}]},"type":"LoadBalancer","kind":"Service","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '514'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/guestbook","uid":"aeb4449f-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4770","creationTimestamp":"2019-01-26T06:21:57Z","labels":{"name":"guestbook"}},"spec":{"ports":[{"protocol":"TCP","port":3000,"targetPort":"http-server"}],"selector":{"app":"guestbook"},"clusterIP":"10.107.43.240","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: post
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"master"},"name":"redis-master"},"spec":{"selector":{"app":"redis","role":"master"},"ports":[{"port":6379,"targetPort":"redis-server"}]},"kind":"Service","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '244'
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '545'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-master","uid":"aebcf100-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4774","creationTimestamp":"2019-01-26T06:21:57Z","labels":{"app":"redis","role":"master"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"master"},"clusterIP":"10.105.172.227","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: post
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"slave"},"name":"redis-slave"},"spec":{"selector":{"app":"redis","role":"slave"},"ports":[{"port":6379,"targetPort":"redis-server"}]},"kind":"Service","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '241'
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '538'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-slave","uid":"aec566bf-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4777","creationTimestamp":"2019-01-26T06:21:57Z","labels":{"app":"redis","role":"slave"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"slave"},"clusterIP":"10.105.9.28","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: post
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"guestbook","role":"slave"},"name":"guestbook"},"spec":{"selector":{"app":"guestbook"},"template":{"metadata":{"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000}]}]}},"replicas":3},"kind":"ReplicationController","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '395'
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '943'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"aeca56e4-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4779","generation":1,"creationTimestamp":"2019-01-26T06:21:57Z","labels":{"app":"guestbook","role":"slave"}},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: post
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"master"},"name":"redis-master"},"spec":{"selector":{"app":"redis","role":"master"},"template":{"metadata":{"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379}]}]}},"replicas":1},"kind":"ReplicationController","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '405'
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '950'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"aecef208-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4780","generation":1,"creationTimestamp":"2019-01-26T06:21:57Z","labels":{"app":"redis","role":"master"}},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: post
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"slave"},"name":"redis-slave"},"spec":{"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379}]}]}},"replicas":2},"kind":"ReplicationController","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '420'
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '970'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"aed507e9-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4784","generation":1,"creationTimestamp":"2019-01-26T06:21:57Z","labels":{"app":"redis","role":"slave"}},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: get
+    uri: https://fake.host.com:8443/api/v1/namespaces
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '1341'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"NamespaceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces","resourceVersion":"4788"},"items":[{"metadata":{"name":"default","selfLink":"/api/v1/namespaces/default","uid":"9d6ef6a7-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"11","creationTimestamp":"2019-01-26T05:38:31Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kube-public","selfLink":"/api/v1/namespaces/kube-public","uid":"9fda160f-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"39","creationTimestamp":"2019-01-26T05:38:35Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kube-system","selfLink":"/api/v1/namespaces/kube-system","uid":"9d74f81b-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"12","creationTimestamp":"2019-01-26T05:38:31Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"kube-system\",\"namespace\":\"\"}}\n"}},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"aeac5431-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4766","creationTimestamp":"2019-01-26T06:21:57Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}]}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: get
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Content-Length:
+      - '1636'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ServiceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/kubeclient-ns/services","resourceVersion":"4795"},"items":[{"metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/guestbook","uid":"aeb4449f-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4770","creationTimestamp":"2019-01-26T06:21:57Z","labels":{"name":"guestbook"}},"spec":{"ports":[{"protocol":"TCP","port":3000,"targetPort":"http-server"}],"selector":{"app":"guestbook"},"clusterIP":"10.107.43.240","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}},{"metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-master","uid":"aebcf100-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4774","creationTimestamp":"2019-01-26T06:21:57Z","labels":{"app":"redis","role":"master"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"master"},"clusterIP":"10.105.172.227","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}},{"metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-slave","uid":"aec566bf-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4777","creationTimestamp":"2019-01-26T06:21:57Z","labels":{"app":"redis","role":"slave"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"slave"},"clusterIP":"10.105.9.28","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}]}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: get
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:57 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationControllerList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers","resourceVersion":"4802"},"items":[{"metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"aeca56e4-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4801","generation":1,"creationTimestamp":"2019-01-26T06:21:57Z","labels":{"app":"guestbook","role":"slave"}},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":3,"fullyLabeledReplicas":3,"observedGeneration":1}},{"metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"aecef208-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4798","generation":1,"creationTimestamp":"2019-01-26T06:21:57Z","labels":{"app":"redis","role":"master"}},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":1,"fullyLabeledReplicas":1,"observedGeneration":1}},{"metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"aed507e9-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4784","generation":1,"creationTimestamp":"2019-01-26T06:21:57Z","labels":{"app":"redis","role":"slave"}},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}]}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services/guestbook
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:58 GMT
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"guestbook","kind":"services","uid":"aeb4449f-2132-11e9-87ff-b2fd1d6b143f"}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services/redis-master
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:58 GMT
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"redis-master","kind":"services","uid":"aebcf100-2132-11e9-87ff-b2fd1d6b143f"}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services/redis-slave
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:58 GMT
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"redis-slave","kind":"services","uid":"aec566bf-2132-11e9-87ff-b2fd1d6b143f"}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:56 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:58 GMT
+      Content-Length:
+      - '1089'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"aeca56e4-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4825","generation":2,"creationTimestamp":"2019-01-26T06:21:57Z","deletionTimestamp":"2019-01-26T06:21:58Z","deletionGracePeriodSeconds":0,"labels":{"app":"guestbook","role":"slave"},"finalizers":["orphan"]},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":3,"fullyLabeledReplicas":3,"observedGeneration":1}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:57 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:58 GMT
+      Content-Length:
+      - '1096'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"aecef208-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4827","generation":2,"creationTimestamp":"2019-01-26T06:21:57Z","deletionTimestamp":"2019-01-26T06:21:58Z","deletionGracePeriodSeconds":0,"labels":{"app":"redis","role":"master"},"finalizers":["orphan"]},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":1,"fullyLabeledReplicas":1,"observedGeneration":1}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:57 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:58 GMT
+      Content-Length:
+      - '1116'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"aed507e9-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4829","generation":2,"creationTimestamp":"2019-01-26T06:21:57Z","deletionTimestamp":"2019-01-26T06:21:58Z","deletionGracePeriodSeconds":0,"labels":{"app":"redis","role":"slave"},"finalizers":["orphan"]},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":2,"fullyLabeledReplicas":2,"observedGeneration":1}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:57 GMT
+- request:
+    method: delete
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - fake.host.com:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 06:21:58 GMT
+      Content-Length:
+      - '347'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"aeac5431-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4839","creationTimestamp":"2019-01-26T06:21:57Z","deletionTimestamp":"2019-01-26T06:21:58Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Terminating"}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 06:21:57 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/kubernetes_guestbook_named_params.yml
+++ b/test/cassettes/kubernetes_guestbook_named_params.yml
@@ -1,0 +1,891 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://192.168.64.8:8443/api/v1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:02 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"kind":"APIResourceList","groupVersion":"v1","resources":[{"name":"bindings","singularName":"","namespaced":true,"kind":"Binding","verbs":["create"]},{"name":"componentstatuses","singularName":"","namespaced":false,"kind":"ComponentStatus","verbs":["get","list"],"shortNames":["cs"]},{"name":"configmaps","singularName":"","namespaced":true,"kind":"ConfigMap","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["cm"]},{"name":"endpoints","singularName":"","namespaced":true,"kind":"Endpoints","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ep"]},{"name":"events","singularName":"","namespaced":true,"kind":"Event","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ev"]},{"name":"limitranges","singularName":"","namespaced":true,"kind":"LimitRange","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["limits"]},{"name":"namespaces","singularName":"","namespaced":false,"kind":"Namespace","verbs":["create","delete","get","list","patch","update","watch"],"shortNames":["ns"]},{"name":"namespaces/finalize","singularName":"","namespaced":false,"kind":"Namespace","verbs":["update"]},{"name":"namespaces/status","singularName":"","namespaced":false,"kind":"Namespace","verbs":["get","patch","update"]},{"name":"nodes","singularName":"","namespaced":false,"kind":"Node","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["no"]},{"name":"nodes/proxy","singularName":"","namespaced":false,"kind":"Node","verbs":[]},{"name":"nodes/status","singularName":"","namespaced":false,"kind":"Node","verbs":["get","patch","update"]},{"name":"persistentvolumeclaims","singularName":"","namespaced":true,"kind":"PersistentVolumeClaim","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pvc"]},{"name":"persistentvolumeclaims/status","singularName":"","namespaced":true,"kind":"PersistentVolumeClaim","verbs":["get","patch","update"]},{"name":"persistentvolumes","singularName":"","namespaced":false,"kind":"PersistentVolume","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pv"]},{"name":"persistentvolumes/status","singularName":"","namespaced":false,"kind":"PersistentVolume","verbs":["get","patch","update"]},{"name":"pods","singularName":"","namespaced":true,"kind":"Pod","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["po"],"categories":["all"]},{"name":"pods/attach","singularName":"","namespaced":true,"kind":"Pod","verbs":[]},{"name":"pods/binding","singularName":"","namespaced":true,"kind":"Binding","verbs":["create"]},{"name":"pods/eviction","singularName":"","namespaced":true,"group":"policy","version":"v1beta1","kind":"Eviction","verbs":["create"]},{"name":"pods/exec","singularName":"","namespaced":true,"kind":"Pod","verbs":[]},{"name":"pods/log","singularName":"","namespaced":true,"kind":"Pod","verbs":["get"]},{"name":"pods/portforward","singularName":"","namespaced":true,"kind":"Pod","verbs":[]},{"name":"pods/proxy","singularName":"","namespaced":true,"kind":"Pod","verbs":[]},{"name":"pods/status","singularName":"","namespaced":true,"kind":"Pod","verbs":["get","patch","update"]},{"name":"podtemplates","singularName":"","namespaced":true,"kind":"PodTemplate","verbs":["create","delete","deletecollection","get","list","patch","update","watch"]},{"name":"replicationcontrollers","singularName":"","namespaced":true,"kind":"ReplicationController","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["rc"],"categories":["all"]},{"name":"replicationcontrollers/scale","singularName":"","namespaced":true,"group":"autoscaling","version":"v1","kind":"Scale","verbs":["get","patch","update"]},{"name":"replicationcontrollers/status","singularName":"","namespaced":true,"kind":"ReplicationController","verbs":["get","patch","update"]},{"name":"resourcequotas","singularName":"","namespaced":true,"kind":"ResourceQuota","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["quota"]},{"name":"resourcequotas/status","singularName":"","namespaced":true,"kind":"ResourceQuota","verbs":["get","patch","update"]},{"name":"secrets","singularName":"","namespaced":true,"kind":"Secret","verbs":["create","delete","deletecollection","get","list","patch","update","watch"]},{"name":"serviceaccounts","singularName":"","namespaced":true,"kind":"ServiceAccount","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["sa"]},{"name":"services","singularName":"","namespaced":true,"kind":"Service","verbs":["create","delete","get","list","patch","update","watch"],"shortNames":["svc"],"categories":["all"]},{"name":"services/proxy","singularName":"","namespaced":true,"kind":"Service","verbs":[]},{"name":"services/status","singularName":"","namespaced":true,"kind":"Service","verbs":["get","patch","update"]}]}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:02 GMT
+      Content-Length:
+      - '206'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"namespaces
+        \"kubeclient-ns\" not found","reason":"NotFound","details":{"name":"kubeclient-ns","kind":"namespaces"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services/guestbook
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:02 GMT
+      Content-Length:
+      - '194'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"services
+        \"guestbook\" not found","reason":"NotFound","details":{"name":"guestbook","kind":"services"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services/redis-master
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:02 GMT
+      Content-Length:
+      - '200'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"services
+        \"redis-master\" not found","reason":"NotFound","details":{"name":"redis-master","kind":"services"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services/redis-slave
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:02 GMT
+      Content-Length:
+      - '198'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"services
+        \"redis-slave\" not found","reason":"NotFound","details":{"name":"redis-slave","kind":"services"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:02 GMT
+      Content-Length:
+      - '222'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"replicationcontrollers
+        \"guestbook\" not found","reason":"NotFound","details":{"name":"guestbook","kind":"replicationcontrollers"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:02 GMT
+      Content-Length:
+      - '228'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"replicationcontrollers
+        \"redis-master\" not found","reason":"NotFound","details":{"name":"redis-master","kind":"replicationcontrollers"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:02 GMT
+      Content-Length:
+      - '226'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"replicationcontrollers
+        \"redis-slave\" not found","reason":"NotFound","details":{"name":"redis-slave","kind":"replicationcontrollers"},"code":404}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: post
+    uri: https://192.168.64.8:8443/api/v1/namespaces
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"name":"kubeclient-ns"},"kind":"Namespace","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '74'
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:02 GMT
+      Content-Length:
+      - '298'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"b03027fb-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"399","creationTimestamp":"2019-01-26T05:39:02Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: post
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"name":"guestbook"},"name":"guestbook"},"spec":{"selector":{"app":"guestbook"},"ports":[{"port":3000,"targetPort":"http-server"}]},"type":"LoadBalancer","kind":"Service","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '239'
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '512'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/guestbook","uid":"b0343d4f-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"402","creationTimestamp":"2019-01-26T05:39:03Z","labels":{"name":"guestbook"}},"spec":{"ports":[{"protocol":"TCP","port":3000,"targetPort":"http-server"}],"selector":{"app":"guestbook"},"clusterIP":"10.99.140.71","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: post
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"master"},"name":"redis-master"},"spec":{"selector":{"app":"redis","role":"master"},"ports":[{"port":6379,"targetPort":"redis-server"}]},"kind":"Service","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '244'
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '542'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-master","uid":"b03a8289-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"407","creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"master"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"master"},"clusterIP":"10.98.204.51","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: post
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"slave"},"name":"redis-slave"},"spec":{"selector":{"app":"redis","role":"slave"},"ports":[{"port":6379,"targetPort":"redis-server"}]},"kind":"Service","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '241'
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '539'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-slave","uid":"b03fd709-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"410","creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"slave"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"slave"},"clusterIP":"10.98.243.140","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: post
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"guestbook","role":"slave"},"name":"guestbook"},"spec":{"selector":{"app":"guestbook"},"template":{"metadata":{"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000}]}]}},"replicas":3},"kind":"ReplicationController","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '395'
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '942'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"b044f4dc-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"412","generation":1,"creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"guestbook","role":"slave"}},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: post
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"master"},"name":"redis-master"},"spec":{"selector":{"app":"redis","role":"master"},"template":{"metadata":{"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379}]}]}},"replicas":1},"kind":"ReplicationController","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '405'
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '949'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"b048c7ea-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"413","generation":1,"creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"master"}},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: post
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
+    body:
+      encoding: UTF-8
+      string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"slave"},"name":"redis-slave"},"spec":{"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379}]}]}},"replicas":2},"kind":"ReplicationController","apiVersion":"v1"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '420'
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '969'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"b04e59c2-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"417","generation":1,"creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"slave"}},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: get
+    uri: https://192.168.64.8:8443/api/v1/namespaces
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '1339'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"NamespaceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces","resourceVersion":"421"},"items":[{"metadata":{"name":"default","selfLink":"/api/v1/namespaces/default","uid":"9d6ef6a7-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"11","creationTimestamp":"2019-01-26T05:38:31Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kube-public","selfLink":"/api/v1/namespaces/kube-public","uid":"9fda160f-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"39","creationTimestamp":"2019-01-26T05:38:35Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kube-system","selfLink":"/api/v1/namespaces/kube-system","uid":"9d74f81b-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"12","creationTimestamp":"2019-01-26T05:38:31Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"kube-system\",\"namespace\":\"\"}}\n"}},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"b03027fb-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"399","creationTimestamp":"2019-01-26T05:39:02Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}]}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: get
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '1631'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ServiceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/kubeclient-ns/services","resourceVersion":"430"},"items":[{"metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/guestbook","uid":"b0343d4f-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"402","creationTimestamp":"2019-01-26T05:39:03Z","labels":{"name":"guestbook"}},"spec":{"ports":[{"protocol":"TCP","port":3000,"targetPort":"http-server"}],"selector":{"app":"guestbook"},"clusterIP":"10.99.140.71","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}},{"metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-master","uid":"b03a8289-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"407","creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"master"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"master"},"clusterIP":"10.98.204.51","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}},{"metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-slave","uid":"b03fd709-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"410","creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"slave"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"slave"},"clusterIP":"10.98.243.140","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}]}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: get
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationControllerList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers","resourceVersion":"433"},"items":[{"metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"b044f4dc-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"428","generation":1,"creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"guestbook","role":"slave"}},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0,"observedGeneration":1}},{"metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"b048c7ea-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"424","generation":1,"creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"master"}},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0,"observedGeneration":1}},{"metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"b04e59c2-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"417","generation":1,"creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"slave"}},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}]}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services/guestbook
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"guestbook","kind":"services","uid":"b0343d4f-212c-11e9-87ff-b2fd1d6b143f"}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services/redis-master
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"redis-master","kind":"services","uid":"b03a8289-212c-11e9-87ff-b2fd1d6b143f"}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services/redis-slave
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"redis-slave","kind":"services","uid":"b03fd709-212c-11e9-87ff-b2fd1d6b143f"}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '1088'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"b044f4dc-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"459","generation":2,"creationTimestamp":"2019-01-26T05:39:03Z","deletionTimestamp":"2019-01-26T05:39:03Z","deletionGracePeriodSeconds":0,"labels":{"app":"guestbook","role":"slave"},"finalizers":["orphan"]},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":3,"fullyLabeledReplicas":3,"observedGeneration":1}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:04 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '1095'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"b048c7ea-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"465","generation":2,"creationTimestamp":"2019-01-26T05:39:03Z","deletionTimestamp":"2019-01-26T05:39:03Z","deletionGracePeriodSeconds":0,"labels":{"app":"redis","role":"master"},"finalizers":["orphan"]},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":1,"fullyLabeledReplicas":1,"observedGeneration":1}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:04 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '1115'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"b04e59c2-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"470","generation":2,"creationTimestamp":"2019-01-26T05:39:03Z","deletionTimestamp":"2019-01-26T05:39:03Z","deletionGracePeriodSeconds":0,"labels":{"app":"redis","role":"slave"},"finalizers":["orphan"]},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":2,"fullyLabeledReplicas":2,"observedGeneration":1}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:04 GMT
+- request:
+    method: delete
+    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Host:
+      - 192.168.64.8:8443
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 26 Jan 2019 05:39:03 GMT
+      Content-Length:
+      - '346'
+    body:
+      encoding: UTF-8
+      string: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"b03027fb-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"476","creationTimestamp":"2019-01-26T05:39:02Z","deletionTimestamp":"2019-01-26T05:39:03Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Terminating"}}
+
+'
+    http_version: 
+  recorded_at: Sat, 26 Jan 2019 05:39:04 GMT
+recorded_with: VCR 4.0.0

--- a/test/cassettes/kubernetes_guestbook_named_params.yml
+++ b/test/cassettes/kubernetes_guestbook_named_params.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://192.168.64.8:8443/api/v1
+    uri: https://fake.host.com:8443/api/v1
     body:
       encoding: US-ASCII
       string: ''
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 200
@@ -23,7 +23,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:02 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Transfer-Encoding:
       - chunked
     body:
@@ -32,10 +32,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns
     body:
       encoding: US-ASCII
       string: ''
@@ -49,7 +49,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 404
@@ -58,7 +58,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:02 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Content-Length:
       - '206'
     body:
@@ -68,10 +68,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services/guestbook
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services/guestbook
     body:
       encoding: US-ASCII
       string: ''
@@ -85,7 +85,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 404
@@ -94,7 +94,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:02 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Content-Length:
       - '194'
     body:
@@ -104,10 +104,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services/redis-master
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services/redis-master
     body:
       encoding: US-ASCII
       string: ''
@@ -121,7 +121,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 404
@@ -130,7 +130,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:02 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Content-Length:
       - '200'
     body:
@@ -140,10 +140,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services/redis-slave
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services/redis-slave
     body:
       encoding: US-ASCII
       string: ''
@@ -157,7 +157,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 404
@@ -166,7 +166,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:02 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Content-Length:
       - '198'
     body:
@@ -176,10 +176,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook
     body:
       encoding: US-ASCII
       string: ''
@@ -193,7 +193,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 404
@@ -202,7 +202,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:02 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Content-Length:
       - '222'
     body:
@@ -212,10 +212,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master
     body:
       encoding: US-ASCII
       string: ''
@@ -229,7 +229,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 404
@@ -238,7 +238,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:02 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Content-Length:
       - '228'
     body:
@@ -248,10 +248,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave
     body:
       encoding: US-ASCII
       string: ''
@@ -265,7 +265,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 404
@@ -274,7 +274,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:02 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Content-Length:
       - '226'
     body:
@@ -284,10 +284,10 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: post
-    uri: https://192.168.64.8:8443/api/v1/namespaces
+    uri: https://fake.host.com:8443/api/v1/namespaces
     body:
       encoding: UTF-8
       string: '{"metadata":{"name":"kubeclient-ns"},"kind":"Namespace","apiVersion":"v1"}'
@@ -303,7 +303,7 @@ http_interactions:
       Content-Length:
       - '74'
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 201
@@ -312,19 +312,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:02 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Content-Length:
-      - '298'
+      - '299'
     body:
       encoding: UTF-8
-      string: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"b03027fb-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"399","creationTimestamp":"2019-01-26T05:39:02Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}
+      string: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"806e4e02-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4541","creationTimestamp":"2019-01-26T06:20:39Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: post
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services
     body:
       encoding: UTF-8
       string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"name":"guestbook"},"name":"guestbook"},"spec":{"selector":{"app":"guestbook"},"ports":[{"port":3000,"targetPort":"http-server"}]},"type":"LoadBalancer","kind":"Service","apiVersion":"v1"}'
@@ -340,7 +340,7 @@ http_interactions:
       Content-Length:
       - '239'
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 201
@@ -349,19 +349,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Content-Length:
-      - '512'
+      - '514'
     body:
       encoding: UTF-8
-      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/guestbook","uid":"b0343d4f-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"402","creationTimestamp":"2019-01-26T05:39:03Z","labels":{"name":"guestbook"}},"spec":{"ports":[{"protocol":"TCP","port":3000,"targetPort":"http-server"}],"selector":{"app":"guestbook"},"clusterIP":"10.99.140.71","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}
+      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/guestbook","uid":"80736ef9-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4544","creationTimestamp":"2019-01-26T06:20:39Z","labels":{"name":"guestbook"}},"spec":{"ports":[{"protocol":"TCP","port":3000,"targetPort":"http-server"}],"selector":{"app":"guestbook"},"clusterIP":"10.107.15.245","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: post
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services
     body:
       encoding: UTF-8
       string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"master"},"name":"redis-master"},"spec":{"selector":{"app":"redis","role":"master"},"ports":[{"port":6379,"targetPort":"redis-server"}]},"kind":"Service","apiVersion":"v1"}'
@@ -377,7 +377,7 @@ http_interactions:
       Content-Length:
       - '244'
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 201
@@ -386,19 +386,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Content-Length:
-      - '542'
+      - '543'
     body:
       encoding: UTF-8
-      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-master","uid":"b03a8289-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"407","creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"master"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"master"},"clusterIP":"10.98.204.51","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}
+      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-master","uid":"8079ad20-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4551","creationTimestamp":"2019-01-26T06:20:39Z","labels":{"app":"redis","role":"master"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"master"},"clusterIP":"10.98.98.196","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: post
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services
     body:
       encoding: UTF-8
       string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"slave"},"name":"redis-slave"},"spec":{"selector":{"app":"redis","role":"slave"},"ports":[{"port":6379,"targetPort":"redis-server"}]},"kind":"Service","apiVersion":"v1"}'
@@ -414,7 +414,7 @@ http_interactions:
       Content-Length:
       - '241'
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 201
@@ -423,19 +423,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Content-Length:
-      - '539'
+      - '541'
     body:
       encoding: UTF-8
-      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-slave","uid":"b03fd709-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"410","creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"slave"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"slave"},"clusterIP":"10.98.243.140","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}
+      string: '{"kind":"Service","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-slave","uid":"80814da0-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4554","creationTimestamp":"2019-01-26T06:20:39Z","labels":{"app":"redis","role":"slave"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"slave"},"clusterIP":"10.108.202.243","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: post
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
     body:
       encoding: UTF-8
       string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"guestbook","role":"slave"},"name":"guestbook"},"spec":{"selector":{"app":"guestbook"},"template":{"metadata":{"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000}]}]}},"replicas":3},"kind":"ReplicationController","apiVersion":"v1"}'
@@ -451,7 +451,7 @@ http_interactions:
       Content-Length:
       - '395'
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 201
@@ -460,19 +460,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:39 GMT
       Content-Length:
-      - '942'
+      - '943'
     body:
       encoding: UTF-8
-      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"b044f4dc-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"412","generation":1,"creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"guestbook","role":"slave"}},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"8086d508-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4556","generation":1,"creationTimestamp":"2019-01-26T06:20:39Z","labels":{"app":"guestbook","role":"slave"}},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: post
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
     body:
       encoding: UTF-8
       string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"master"},"name":"redis-master"},"spec":{"selector":{"app":"redis","role":"master"},"template":{"metadata":{"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379}]}]}},"replicas":1},"kind":"ReplicationController","apiVersion":"v1"}'
@@ -488,7 +488,7 @@ http_interactions:
       Content-Length:
       - '405'
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 201
@@ -497,19 +497,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:40 GMT
       Content-Length:
-      - '949'
+      - '950'
     body:
       encoding: UTF-8
-      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"b048c7ea-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"413","generation":1,"creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"master"}},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"808ced1d-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4558","generation":1,"creationTimestamp":"2019-01-26T06:20:40Z","labels":{"app":"redis","role":"master"}},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: post
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
     body:
       encoding: UTF-8
       string: '{"metadata":{"namespace":"kubeclient-ns","labels":{"app":"redis","role":"slave"},"name":"redis-slave"},"spec":{"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379}]}]}},"replicas":2},"kind":"ReplicationController","apiVersion":"v1"}'
@@ -525,7 +525,7 @@ http_interactions:
       Content-Length:
       - '420'
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 201
@@ -534,19 +534,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:40 GMT
       Content-Length:
-      - '969'
+      - '970'
     body:
       encoding: UTF-8
-      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"b04e59c2-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"417","generation":1,"creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"slave"}},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"809673fc-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4564","generation":1,"creationTimestamp":"2019-01-26T06:20:40Z","labels":{"app":"redis","role":"slave"}},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: get
-    uri: https://192.168.64.8:8443/api/v1/namespaces
+    uri: https://fake.host.com:8443/api/v1/namespaces
     body:
       encoding: US-ASCII
       string: ''
@@ -558,7 +558,7 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 200
@@ -567,19 +567,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:40 GMT
       Content-Length:
-      - '1339'
+      - '1341'
     body:
       encoding: UTF-8
-      string: '{"kind":"NamespaceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces","resourceVersion":"421"},"items":[{"metadata":{"name":"default","selfLink":"/api/v1/namespaces/default","uid":"9d6ef6a7-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"11","creationTimestamp":"2019-01-26T05:38:31Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kube-public","selfLink":"/api/v1/namespaces/kube-public","uid":"9fda160f-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"39","creationTimestamp":"2019-01-26T05:38:35Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kube-system","selfLink":"/api/v1/namespaces/kube-system","uid":"9d74f81b-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"12","creationTimestamp":"2019-01-26T05:38:31Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"kube-system\",\"namespace\":\"\"}}\n"}},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"b03027fb-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"399","creationTimestamp":"2019-01-26T05:39:02Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}]}
+      string: '{"kind":"NamespaceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces","resourceVersion":"4572"},"items":[{"metadata":{"name":"default","selfLink":"/api/v1/namespaces/default","uid":"9d6ef6a7-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"11","creationTimestamp":"2019-01-26T05:38:31Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kube-public","selfLink":"/api/v1/namespaces/kube-public","uid":"9fda160f-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"39","creationTimestamp":"2019-01-26T05:38:35Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kube-system","selfLink":"/api/v1/namespaces/kube-system","uid":"9d74f81b-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"12","creationTimestamp":"2019-01-26T05:38:31Z","annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{},\"name\":\"kube-system\",\"namespace\":\"\"}}\n"}},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}},{"metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"806e4e02-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4541","creationTimestamp":"2019-01-26T06:20:39Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Active"}}]}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: get
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services
     body:
       encoding: US-ASCII
       string: ''
@@ -591,7 +591,7 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 200
@@ -600,19 +600,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:40 GMT
       Content-Length:
-      - '1631'
+      - '1637'
     body:
       encoding: UTF-8
-      string: '{"kind":"ServiceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/kubeclient-ns/services","resourceVersion":"430"},"items":[{"metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/guestbook","uid":"b0343d4f-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"402","creationTimestamp":"2019-01-26T05:39:03Z","labels":{"name":"guestbook"}},"spec":{"ports":[{"protocol":"TCP","port":3000,"targetPort":"http-server"}],"selector":{"app":"guestbook"},"clusterIP":"10.99.140.71","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}},{"metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-master","uid":"b03a8289-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"407","creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"master"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"master"},"clusterIP":"10.98.204.51","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}},{"metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-slave","uid":"b03fd709-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"410","creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"slave"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"slave"},"clusterIP":"10.98.243.140","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}]}
+      string: '{"kind":"ServiceList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/kubeclient-ns/services","resourceVersion":"4578"},"items":[{"metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/guestbook","uid":"80736ef9-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4544","creationTimestamp":"2019-01-26T06:20:39Z","labels":{"name":"guestbook"}},"spec":{"ports":[{"protocol":"TCP","port":3000,"targetPort":"http-server"}],"selector":{"app":"guestbook"},"clusterIP":"10.107.15.245","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}},{"metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-master","uid":"8079ad20-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4551","creationTimestamp":"2019-01-26T06:20:39Z","labels":{"app":"redis","role":"master"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"master"},"clusterIP":"10.98.98.196","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}},{"metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/services/redis-slave","uid":"80814da0-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4554","creationTimestamp":"2019-01-26T06:20:39Z","labels":{"app":"redis","role":"slave"}},"spec":{"ports":[{"protocol":"TCP","port":6379,"targetPort":"redis-server"}],"selector":{"app":"redis","role":"slave"},"clusterIP":"10.108.202.243","type":"ClusterIP","sessionAffinity":"None"},"status":{"loadBalancer":{}}}]}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:38 GMT
 - request:
     method: get
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers
     body:
       encoding: US-ASCII
       string: ''
@@ -624,7 +624,7 @@ http_interactions:
       User-Agent:
       - rest-client/2.0.2 (darwin17.5.0 x86_64) ruby/2.5.1p57
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 200
@@ -633,19 +633,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:40 GMT
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: '{"kind":"ReplicationControllerList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers","resourceVersion":"433"},"items":[{"metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"b044f4dc-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"428","generation":1,"creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"guestbook","role":"slave"}},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0,"observedGeneration":1}},{"metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"b048c7ea-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"424","generation":1,"creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"master"}},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0,"observedGeneration":1}},{"metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"b04e59c2-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"417","generation":1,"creationTimestamp":"2019-01-26T05:39:03Z","labels":{"app":"redis","role":"slave"}},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}]}
+      string: '{"kind":"ReplicationControllerList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers","resourceVersion":"4581"},"items":[{"metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"8086d508-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4574","generation":1,"creationTimestamp":"2019-01-26T06:20:39Z","labels":{"app":"guestbook","role":"slave"}},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":3,"fullyLabeledReplicas":3,"observedGeneration":1}},{"metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"808ced1d-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4578","generation":1,"creationTimestamp":"2019-01-26T06:20:40Z","labels":{"app":"redis","role":"master"}},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":1,"fullyLabeledReplicas":1,"observedGeneration":1}},{"metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"809673fc-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4564","generation":1,"creationTimestamp":"2019-01-26T06:20:40Z","labels":{"app":"redis","role":"slave"}},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":0}}]}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:39 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services/guestbook
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services/guestbook
     body:
       encoding: US-ASCII
       string: ''
@@ -659,7 +659,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 200
@@ -668,19 +668,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:40 GMT
       Content-Length:
       - '163'
     body:
       encoding: UTF-8
-      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"guestbook","kind":"services","uid":"b0343d4f-212c-11e9-87ff-b2fd1d6b143f"}}
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"guestbook","kind":"services","uid":"80736ef9-2132-11e9-87ff-b2fd1d6b143f"}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:39 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services/redis-master
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services/redis-master
     body:
       encoding: US-ASCII
       string: ''
@@ -694,7 +694,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 200
@@ -703,19 +703,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:40 GMT
       Content-Length:
       - '166'
     body:
       encoding: UTF-8
-      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"redis-master","kind":"services","uid":"b03a8289-212c-11e9-87ff-b2fd1d6b143f"}}
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"redis-master","kind":"services","uid":"8079ad20-2132-11e9-87ff-b2fd1d6b143f"}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:39 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/services/redis-slave
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/services/redis-slave
     body:
       encoding: US-ASCII
       string: ''
@@ -729,7 +729,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 200
@@ -738,19 +738,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:40 GMT
       Content-Length:
       - '165'
     body:
       encoding: UTF-8
-      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"redis-slave","kind":"services","uid":"b03fd709-212c-11e9-87ff-b2fd1d6b143f"}}
+      string: '{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success","details":{"name":"redis-slave","kind":"services","uid":"80814da0-2132-11e9-87ff-b2fd1d6b143f"}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:03 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:39 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook
     body:
       encoding: US-ASCII
       string: ''
@@ -764,7 +764,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 200
@@ -773,19 +773,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:40 GMT
       Content-Length:
-      - '1088'
+      - '1089'
     body:
       encoding: UTF-8
-      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"b044f4dc-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"459","generation":2,"creationTimestamp":"2019-01-26T05:39:03Z","deletionTimestamp":"2019-01-26T05:39:03Z","deletionGracePeriodSeconds":0,"labels":{"app":"guestbook","role":"slave"},"finalizers":["orphan"]},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":3,"fullyLabeledReplicas":3,"observedGeneration":1}}
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"guestbook","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/guestbook","uid":"8086d508-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4603","generation":2,"creationTimestamp":"2019-01-26T06:20:39Z","deletionTimestamp":"2019-01-26T06:20:40Z","deletionGracePeriodSeconds":0,"labels":{"app":"guestbook","role":"slave"},"finalizers":["orphan"]},"spec":{"replicas":3,"selector":{"app":"guestbook"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"guestbook"}},"spec":{"containers":[{"name":"guestbook","image":"kubernetes/guestbook:v2","ports":[{"name":"http-server","containerPort":3000,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":3,"fullyLabeledReplicas":3,"observedGeneration":1}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:04 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:39 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master
     body:
       encoding: US-ASCII
       string: ''
@@ -799,7 +799,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 200
@@ -808,19 +808,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:40 GMT
       Content-Length:
-      - '1095'
+      - '1096'
     body:
       encoding: UTF-8
-      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"b048c7ea-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"465","generation":2,"creationTimestamp":"2019-01-26T05:39:03Z","deletionTimestamp":"2019-01-26T05:39:03Z","deletionGracePeriodSeconds":0,"labels":{"app":"redis","role":"master"},"finalizers":["orphan"]},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":1,"fullyLabeledReplicas":1,"observedGeneration":1}}
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-master","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-master","uid":"808ced1d-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4605","generation":2,"creationTimestamp":"2019-01-26T06:20:40Z","deletionTimestamp":"2019-01-26T06:20:40Z","deletionGracePeriodSeconds":0,"labels":{"app":"redis","role":"master"},"finalizers":["orphan"]},"spec":{"replicas":1,"selector":{"app":"redis","role":"master"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"master"}},"spec":{"containers":[{"name":"redis-master","image":"redis","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"Always"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":1,"fullyLabeledReplicas":1,"observedGeneration":1}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:04 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:39 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave
     body:
       encoding: US-ASCII
       string: ''
@@ -834,7 +834,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 200
@@ -843,19 +843,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:40 GMT
       Content-Length:
-      - '1115'
+      - '1116'
     body:
       encoding: UTF-8
-      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"b04e59c2-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"470","generation":2,"creationTimestamp":"2019-01-26T05:39:03Z","deletionTimestamp":"2019-01-26T05:39:03Z","deletionGracePeriodSeconds":0,"labels":{"app":"redis","role":"slave"},"finalizers":["orphan"]},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":2,"fullyLabeledReplicas":2,"observedGeneration":1}}
+      string: '{"kind":"ReplicationController","apiVersion":"v1","metadata":{"name":"redis-slave","namespace":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns/replicationcontrollers/redis-slave","uid":"809673fc-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4608","generation":2,"creationTimestamp":"2019-01-26T06:20:40Z","deletionTimestamp":"2019-01-26T06:20:40Z","deletionGracePeriodSeconds":0,"labels":{"app":"redis","role":"slave"},"finalizers":["orphan"]},"spec":{"replicas":2,"selector":{"app":"redis","role":"slave"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"redis","role":"slave"}},"spec":{"containers":[{"name":"redis-slave","image":"kubernetes/redis-slave:v2","ports":[{"name":"redis-server","containerPort":6379,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":30,"dnsPolicy":"ClusterFirst","securityContext":{},"schedulerName":"default-scheduler"}}},"status":{"replicas":2,"fullyLabeledReplicas":2,"observedGeneration":1}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:04 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:39 GMT
 - request:
     method: delete
-    uri: https://192.168.64.8:8443/api/v1/namespaces/kubeclient-ns
+    uri: https://fake.host.com:8443/api/v1/namespaces/kubeclient-ns
     body:
       encoding: US-ASCII
       string: ''
@@ -869,7 +869,7 @@ http_interactions:
       Content-Type:
       - application/json
       Host:
-      - 192.168.64.8:8443
+      - fake.host.com:8443
   response:
     status:
       code: 200
@@ -878,14 +878,14 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 26 Jan 2019 05:39:03 GMT
+      - Sat, 26 Jan 2019 06:20:40 GMT
       Content-Length:
-      - '346'
+      - '347'
     body:
       encoding: UTF-8
-      string: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"b03027fb-212c-11e9-87ff-b2fd1d6b143f","resourceVersion":"476","creationTimestamp":"2019-01-26T05:39:02Z","deletionTimestamp":"2019-01-26T05:39:03Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Terminating"}}
+      string: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"kubeclient-ns","selfLink":"/api/v1/namespaces/kubeclient-ns","uid":"806e4e02-2132-11e9-87ff-b2fd1d6b143f","resourceVersion":"4612","creationTimestamp":"2019-01-26T06:20:39Z","deletionTimestamp":"2019-01-26T06:20:40Z"},"spec":{"finalizers":["kubernetes"]},"status":{"phase":"Terminating"}}
 
 '
     http_version: 
-  recorded_at: Sat, 26 Jan 2019 05:39:04 GMT
+  recorded_at: Sat, 26 Jan 2019 06:20:39 GMT
 recorded_with: VCR 4.0.0

--- a/test/test_guestbook_go.rb
+++ b/test/test_guestbook_go.rb
@@ -6,12 +6,16 @@ class CreateGuestbookGo < MiniTest::Test
   def test_create_guestbook_entities
     VCR.configure do |c|
       c.cassette_library_dir = 'test/cassettes'
+      c.filter_sensitive_data("fake.host.com") do |interaction|
+        uri = interaction.request.uri
+        URI.parse(uri).host
+      end
       c.hook_into(:webmock)
     end
 
     # WebMock.allow_net_connect!
     VCR.use_cassette('kubernetes_guestbook') do # , record: :new_episodes) do
-      client = Kubeclient::Client.new('http://10.35.0.23:8080/api/', 'v1')
+      client = Kubeclient::Client.new('https://fake.host.com:8443/api/', 'v1')
 
       testing_ns = Kubeclient::Resource.new
       testing_ns.metadata = {}

--- a/test/test_guestbook_named_params.rb
+++ b/test/test_guestbook_named_params.rb
@@ -1,0 +1,235 @@
+require_relative 'test_helper'
+require 'vcr'
+
+# creation of google's example of guest book
+class CreateGuestbookGoNamedParams < MiniTest::Test
+  def test_create_guestbook_entities
+    VCR.configure do |c|
+      c.cassette_library_dir = 'test/cassettes'
+      c.hook_into(:webmock)
+    end
+
+    # WebMock.allow_net_connect!
+    VCR.use_cassette('kubernetes_guestbook_named_params') do # , record: :new_episodes) do
+      client = Kubeclient::Client.new('http://10.35.0.23:8080/api/', 'v1')
+
+      testing_ns = Kubeclient::Resource.new
+      testing_ns.metadata = {}
+      testing_ns.metadata.name = 'kubeclient-ns'
+
+      # delete in case they existed before so creation can be tested
+      delete_namespace(client, testing_ns.metadata.name)
+      delete_services(
+        client, testing_ns.metadata.name,
+        ['guestbook', 'redis-master', 'redis-slave']
+      )
+      delete_replication_controllers(
+        client, testing_ns.metadata.name,
+        ['guestbook', 'redis-master', 'redis-slave']
+      )
+
+      client.create_namespace(testing_ns)
+      services = create_services(client, testing_ns.metadata.name)
+      replicators = create_replication_controllers(client, testing_ns.metadata.name)
+
+      get_namespaces(client)
+      get_services(client, testing_ns.metadata.name)
+      get_replication_controllers(client, testing_ns.metadata.name)
+
+      delete_services(client, testing_ns.metadata.name, services)
+      delete_replication_controllers(client, testing_ns.metadata.name, replicators)
+
+      client.delete_namespace(name: testing_ns.metadata.name)
+    end
+  end
+
+  def delete_namespace(client, namespace_name)
+    client.delete_namespace(name: namespace_name)
+  rescue Kubeclient::ResourceNotFoundError => exception
+    assert_equal(404, exception.error_code)
+  end
+
+  def get_namespaces(client)
+    namespaces = client.get_namespaces
+    assert(true, namespaces.size > 2)
+  end
+
+  def get_services(client, ns)
+    retrieved_services = client.get_services(namespace: ns)
+    assert_equal(3, retrieved_services.size)
+  end
+
+  def get_replication_controllers(client, ns)
+    retrieved_replicators = client.get_replication_controllers(namespace: ns)
+    assert_equal(3, retrieved_replicators.size)
+  end
+
+  def create_services(client, ns)
+    guestbook_service = client.create_service(guestbook_service(ns))
+    redis_service = client.create_service(redis_service(ns))
+    redis_slave_service = client.create_service(redis_slave_service(ns))
+    [guestbook_service, redis_service, redis_slave_service]
+  end
+
+  def create_replication_controllers(client, namespace)
+    rc = client.create_replication_controller(guestbook_rc(namespace))
+    rc2 = client.create_replication_controller(redis_master_rc(namespace))
+    rc3 = client.create_replication_controller(redis_slave_rc(namespace))
+    [rc, rc2, rc3]
+  end
+
+  def delete_services(client, namespace, services)
+    # if the entity is not found, no need to fail the test
+    services.each do |service|
+      begin
+        if service.instance_of?(Kubeclient::Resource)
+          client.delete_service(name: service.metadata.name, namespace: namespace)
+        else
+          # it's just a string - service name
+          client.delete_service(name: service, namespace: namespace)
+        end
+      rescue Kubeclient::ResourceNotFoundError => exception
+        assert_equal(404, exception.error_code)
+      end
+    end
+  end
+
+  def delete_replication_controllers(client, namespace, replication_controllers)
+    # if the entity is not found, no need to fail the test
+    replication_controllers.each do |rc|
+      begin
+        if rc.instance_of?(Kubeclient::Resource)
+          client.delete_replication_controller(name: rc.metadata.name, namespace: namespace)
+        else
+          # it's just a string - rc name
+          client.delete_replication_controller(name: rc, namespace: namespace)
+        end
+      rescue Kubeclient::ResourceNotFoundError => exception
+        assert_equal(404, exception.error_code)
+      end
+    end
+  end
+
+  private
+
+  def construct_base_rc(namespace)
+    rc = Kubeclient::Resource.new
+    rc.metadata = {}
+    rc.metadata.namespace = namespace
+    rc.metadata.labels = {}
+    rc.spec = {}
+    rc.spec.selector = {}
+    rc.spec.template = {}
+    rc.spec.template.metadata = {}
+    rc.spec.template.spec = {}
+    rc.spec.template.metadata.labels = {}
+    rc
+  end
+
+  def redis_master_rc(namespace)
+    rc = construct_base_rc(namespace)
+    rc.metadata.name = 'redis-master'
+    rc.metadata.labels.app = 'redis'
+    rc.metadata.labels.role = 'master'
+    rc.spec.replicas = 1
+    rc.spec.selector.app = 'redis'
+    rc.spec.selector.role = 'master'
+    rc.spec.template.metadata.labels.app = 'redis'
+    rc.spec.template.metadata.labels.role = 'master'
+    rc.spec.template.spec.containers = [{
+      'name' => 'redis-master',
+      'image' => 'redis',
+      'ports' => [{
+        'name' => 'redis-server',
+        'containerPort' => 6379
+      }]
+    }]
+    rc
+  end
+
+  def redis_slave_rc(namespace)
+    rc = construct_base_rc(namespace)
+    rc.metadata.name = 'redis-slave'
+    rc.metadata.labels.app = 'redis'
+    rc.metadata.labels.role = 'slave'
+    rc.spec.replicas = 2
+    rc.spec.selector.app = 'redis'
+    rc.spec.selector.role = 'slave'
+    rc.spec.template.metadata.labels.app = 'redis'
+    rc.spec.template.metadata.labels.role = 'slave'
+    rc.spec.template.spec.containers = [{
+      'name'          => 'redis-slave',
+      'image'         => 'kubernetes/redis-slave:v2',
+      'ports'         => [{
+        'name'          => 'redis-server',
+        'containerPort' => 6379
+      }]
+    }]
+    rc
+  end
+
+  def guestbook_rc(namespace)
+    rc = construct_base_rc(namespace)
+    rc.metadata.name = 'guestbook'
+    rc.metadata.labels.app = 'guestbook'
+    rc.metadata.labels.role = 'slave'
+    rc.spec.replicas = 3
+    rc.spec.selector.app = 'guestbook'
+    rc.spec.template.metadata.labels.app = 'guestbook'
+    rc.spec.template.spec.containers = [
+      {
+        'name'     => 'guestbook',
+        'image'    => 'kubernetes/guestbook:v2',
+        'ports'    => [
+          {
+            'name'          => 'http-server',
+            'containerPort' => 3000
+          }
+        ]
+      }
+    ]
+    rc
+  end
+
+  def base_service(namespace)
+    our_service = Kubeclient::Resource.new
+    our_service.metadata = {}
+    our_service.metadata.namespace = namespace
+    our_service.metadata.labels = {}
+    our_service.spec = {}
+    our_service.spec.selector = {}
+    our_service
+  end
+
+  def redis_slave_service(namespace)
+    our_service = base_service(namespace)
+    our_service.metadata.name = 'redis-slave'
+    our_service.metadata.labels.app = 'redis'
+    our_service.metadata.labels.role = 'slave'
+    our_service.spec.ports = [{ 'port' => 6379, 'targetPort' => 'redis-server' }]
+    our_service.spec.selector.app = 'redis'
+    our_service.spec.selector.role = 'slave'
+    our_service
+  end
+
+  def redis_service(namespace)
+    our_service = base_service(namespace)
+    our_service.metadata.name = 'redis-master'
+    our_service.metadata.labels.app = 'redis'
+    our_service.metadata.labels.role = 'master'
+    our_service.spec.ports = [{ 'port' => 6379, 'targetPort' => 'redis-server' }]
+    our_service.spec.selector.app = 'redis'
+    our_service.spec.selector.role = 'master'
+    our_service
+  end
+
+  def guestbook_service(namespace)
+    our_service = base_service(namespace)
+    our_service.metadata.name = 'guestbook'
+    our_service.metadata.labels.name = 'guestbook'
+    our_service.spec.ports = [{ 'port' => 3000, 'targetPort' => 'http-server' }]
+    our_service.spec.selector.app = 'guestbook'
+    our_service.type = 'LoadBalancer'
+    our_service
+  end
+end

--- a/test/test_guestbook_named_params.rb
+++ b/test/test_guestbook_named_params.rb
@@ -6,12 +6,16 @@ class CreateGuestbookGoNamedParams < MiniTest::Test
   def test_create_guestbook_entities
     VCR.configure do |c|
       c.cassette_library_dir = 'test/cassettes'
+      c.filter_sensitive_data("fake.host.com") do |interaction|
+        uri = interaction.request.uri
+        URI.parse(uri).host
+      end
       c.hook_into(:webmock)
     end
 
     # WebMock.allow_net_connect!
     VCR.use_cassette('kubernetes_guestbook_named_params') do # , record: :new_episodes) do
-      client = Kubeclient::Client.new('http://10.35.0.23:8080/api/', 'v1')
+      client = Kubeclient::Client.new('https://fake.host.com:8443/api/', 'v1')
 
       testing_ns = Kubeclient::Resource.new
       testing_ns.metadata = {}


### PR DESCRIPTION
### Goals

Aims to close #312 (Harmonize positional vs keyword namespace args).

For now, I'm looking for validation of the approach or whether or not we want to try solving this a different way.

### Proposed Solution

This solution leverages (abuses?) the fact that ruby captures all named parameters in **kwargs if all other parameters are provided default values. By doing this, we add the ability to supply named parameters to `get`, `delete`, `patch`, etc. while still supporting the previous unnamed parameter implementation. This should provide the means to gracefully deprecate unnamed parameters for these methods moving forward. Once that's done, we can explicitly put the named parameters in the method signatures and clean up the logic for dealing with both cases.

