### PR TITLE
gcp automatic default credentials

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: false
 Metrics/CyclomaticComplexity:
-  Max: 8
+  Max: 9
 Metrics/ModuleLength:
   Enabled: false
 Style/MethodCallWithArgsParentheses:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,9 @@ Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: false
 Metrics/CyclomaticComplexity:
-  Max: 9
+  Max: 8
+Metrics/PerceivedComplexity:
+  Max: 8
 Metrics/ModuleLength:
   Enabled: false
 Style/MethodCallWithArgsParentheses:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 
 ## Unreleased
 
+### Changed
+- `GoogleApplicationDefaultCredentials` will automatically be used in `fetch_user_auth_options` if the `user[auth-provider][name] == 'gcp'` in the provided context. Note that `user[exec]` is checked first in anticipation of this functionality being added to GCP sometime in the future. Kubeclient _does not_ import the required `googleauth` gem, so you will need to import it in your calling application. (#394)
+
 ### Added
 - Support for `json_patch_#{entity}` and `merge_patch_#{entity}`. `patch_#{entity}` will continue to use strategic merge patch.
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ kubeclient can use `googleauth` gem to authorize.
 This requires the [`googleauth` gem](https://github.com/google/google-auth-library-ruby) that is _not_ included in
 `kubeclient` dependencies so you should add it to your bundle.
 
-If you use `Config.context(...).auth_options` and the kubeconfig file has `user: {auth-provider: {name: gcp}}`, kubeclient will automatically try this (raising LoadError if you don't have `googleauth`).
+If you use `Config.context(...).auth_options` and the kubeconfig file has `user: {auth-provider: {name: gcp}}`, kubeclient will automatically try this (raising LoadError if you don't have `googleauth` in your bundle).
 
 Or you can obtain a token manually:
 

--- a/README.md
+++ b/README.md
@@ -166,29 +166,6 @@ namespace = File.read('/var/run/secrets/kubernetes.io/serviceaccount/namespace')
 ```
 You can find information about tokens in [this guide](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod) and in [this reference](http://kubernetes.io/docs/admin/authentication/).
 
-#### Google's Application Default Credentials
-
-On Google Compute Engine, Google App Engine, or Google Cloud Functions, as well as `gcloud`-configured systems
-with [application default credentials](https://developers.google.com/identity/protocols/application-default-credentials),
-you can use the token provider to authorize `kubeclient`.
-
-This requires the [`googleauth` gem](https://github.com/google/google-auth-library-ruby) that is _not_ included in
-`kubeclient` dependencies so you should add it to your bundle.
-
-```ruby
-require 'googleauth'
-
-auth_options = {
-  bearer_token: Kubeclient::GoogleApplicationDefaultCredentials.token
-}
-client = Kubeclient::Client.new(
-  'https://localhost:8443/api/', 'v1', auth_options: auth_options
-)
-```
-
-Note that this token is good for one hour. If your code runs for longer than that, you should plan to
-acquire a new one.
-
 ### Non-blocking IO
 
 You can also use kubeclient with non-blocking sockets such as Celluloid::IO, see [here](https://github.com/httprb/http/wiki/Parallel-requests-with-Celluloid%3A%3AIO)
@@ -308,6 +285,34 @@ Kubeclient::Client.new(
   auth_options: context.auth_options
 )
 ```
+
+
+#### Google's Application Default Credentials
+
+On Google Compute Engine, Google App Engine, or Google Cloud Functions, as well as `gcloud`-configured systems
+with [application default credentials](https://developers.google.com/identity/protocols/application-default-credentials),
+kubeclient can use `googleauth` gem to authorize.
+
+This requires the [`googleauth` gem](https://github.com/google/google-auth-library-ruby) that is _not_ included in
+`kubeclient` dependencies so you should add it to your bundle.
+
+If you use `Config.context(...).auth_options` and the kubeconfig file has `user: {auth-provider: {name: gcp}}`, kubeclient will automatically try this (raising LoadError if you don't have `googleauth`).
+
+Or you can obtain a token manually:
+
+```ruby
+require 'googleauth'
+
+auth_options = {
+  bearer_token: Kubeclient::GoogleApplicationDefaultCredentials.token
+}
+client = Kubeclient::Client.new(
+  'https://localhost:8443/api/', 'v1', auth_options: auth_options
+)
+```
+
+Note that this returns token good for one hour. If your code runs for longer than that, you should plan to
+acquire a new one.
 
 #### Security: Don't use config from untrusted sources
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ client = Kubeclient::Client.new(
 ```
 
 Note that this returns a token good for one hour. If your code requires authorization for longer than that, you should plan to
-acquire a new one.
+acquire a new one, by calling `.context()` or `GoogleApplicationDefaultCredentials.token` again.
 
 #### Security: Don't use config from untrusted sources
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ client = Kubeclient::Client.new(
 )
 ```
 
-Note that this returns token good for one hour. If your code runs for longer than that, you should plan to
+Note that this returns a token good for one hour. If your code requires authorization for longer than that, you should plan to
 acquire a new one.
 
 #### Security: Don't use config from untrusted sources

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'rubocop', '= 0.49.1'
   spec.add_development_dependency 'googleauth', '~> 0.5.1'
+  spec.add_development_dependency('mocha', '~> 1.5')
 
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'recursive-open-struct', '~> 1.0', '>= 1.0.4'

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -147,7 +147,9 @@ module Kubeclient
 
     def fetch_user_auth_options(user)
       options = {}
-      if user.key?('token')
+      if user.dig('auth-provider', 'name') == 'gcp'
+        options[:bearer_token] = Kubeclient::GoogleApplicationDefaultCredentials.token
+      elsif user.key?('token')
         options[:bearer_token] = user['token']
       elsif user.key?('exec')
         exec_opts = user['exec'].dup

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -147,14 +147,14 @@ module Kubeclient
 
     def fetch_user_auth_options(user)
       options = {}
-      if user.key?('auth-provider') && user['auth-provider']['name'] == 'gcp'
-        options[:bearer_token] = Kubeclient::GoogleApplicationDefaultCredentials.token
-      elsif user.key?('token')
+      if user.key?('token')
         options[:bearer_token] = user['token']
       elsif user.key?('exec')
         exec_opts = user['exec'].dup
         exec_opts['command'] = ext_command_path(exec_opts['command']) if exec_opts['command']
         options[:bearer_token] = Kubeclient::ExecCredentials.token(exec_opts)
+      elsif user.key?('auth-provider') && user['auth-provider']['name'] == 'gcp'
+        options[:bearer_token] = Kubeclient::GoogleApplicationDefaultCredentials.token
       else
         %w[username password].each do |attr|
           options[attr.to_sym] = user[attr] if user.key?(attr)

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -147,7 +147,7 @@ module Kubeclient
 
     def fetch_user_auth_options(user)
       options = {}
-      if user.dig('auth-provider', 'name') == 'gcp'
+      if user.key?('auth-provider') && user['auth-provider']['name'] == 'gcp'
         options[:bearer_token] = Kubeclient::GoogleApplicationDefaultCredentials.token
       elsif user.key?('token')
         options[:bearer_token] = user['token']

--- a/lib/kubeclient/google_application_default_credentials.rb
+++ b/lib/kubeclient/google_application_default_credentials.rb
@@ -3,14 +3,18 @@
 module Kubeclient
   # Get a bearer token from the Google's application default credentials.
   class GoogleApplicationDefaultCredentials
+    class GoogleDependencyError < LoadError
+    end
+
     class << self
       def token
         begin
           require 'googleauth'
-        rescue LoadError
-          puts "Gem 'googleauth' not found. Kubeclient does not include the googleauth gem, "\
-          'you must include it in your own application'
-          raise
+        rescue LoadError => e
+          raise GoogleDependencyError,
+                'Error requiring googleauth gem. Kubeclient itself does not include the ' \
+                'googleauth gem. To support auth-provider gcp, you must include it in your ' \
+                "calling application. Failed with: #{e.message}"
         end
         scopes = ['https://www.googleapis.com/auth/cloud-platform']
         authorization = Google::Auth.get_application_default(scopes)

--- a/lib/kubeclient/google_application_default_credentials.rb
+++ b/lib/kubeclient/google_application_default_credentials.rb
@@ -5,7 +5,13 @@ module Kubeclient
   class GoogleApplicationDefaultCredentials
     class << self
       def token
-        require 'googleauth'
+        begin
+          require 'googleauth'
+        rescue LoadError
+          puts "Gem 'googleauth' not found. Kubeclient does not include the googleauth gem, "\
+          'you must include it in your own application'
+          raise
+        end
         scopes = ['https://www.googleapis.com/auth/cloud-platform']
         authorization = Google::Auth.get_application_default(scopes)
         authorization.apply({})

--- a/lib/kubeclient/google_application_default_credentials.rb
+++ b/lib/kubeclient/google_application_default_credentials.rb
@@ -3,7 +3,7 @@
 module Kubeclient
   # Get a bearer token from the Google's application default credentials.
   class GoogleApplicationDefaultCredentials
-    class GoogleDependencyError < LoadError
+    class GoogleDependencyError < LoadError # rubocop:disable Lint/InheritException
     end
 
     class << self

--- a/test/config/gcpauth.kubeconfig
+++ b/test/config/gcpauth.kubeconfig
@@ -1,0 +1,22 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+    insecure-skip-tls-verify: true
+  name: localhost:8443
+contexts:
+- context:
+    cluster: localhost:8443
+    namespace: default
+    user: application-default-credentials
+  name: localhost/application-default-credentials
+kind: Config
+preferences: {}
+users:
+- name: application-default-credentials
+  user:
+    auth-provider:
+      config:
+        access-token: <fake_token>
+        expiry: 2019-02-19T11:07:29.827352-05:00
+      name: gcp

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -123,6 +123,13 @@ class KubeclientConfigTest < MiniTest::Test
     end
   end
 
+  def test_gcp_default_auth
+    Kubeclient::GoogleApplicationDefaultCredentials.expects(:token).returns(:true).once
+    parsed = YAML.safe_load(File.read(config_file('gcpauth.kubeconfig')), [Date, Time])
+    config = Kubeclient::Config.new(parsed, nil)
+    config.context(config.contexts.first)
+  end
+
   private
 
   def check_context(context, ssl: true)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 require 'minitest/autorun'
 require 'minitest/rg'
 require 'webmock/minitest'
+require 'mocha/minitest'
 require 'json'
 require 'kubeclient'
 


### PR DESCRIPTION
Follow-up of #392 

- Adds a check for gcp auth provider and defaults to using GoogleApplicationDefaultCredentials.
- Also added a specific error if `googleauth` gem isn't present on the importing application.
- Brought in Mocha as a dev dependency for mocking. I can use a bare mock if you prefer
- Add a unit test + test kubeconfig file

cc @cben 