### PR TITLE
Don't promise that Config#context is what acts on exec:/auth-provider:  

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ client = Kubeclient::Client.new(
 ```
 
 Note that this returns a token good for one hour. If your code requires authorization for longer than that, you should plan to
-acquire a new one, by calling `.context()` or `GoogleApplicationDefaultCredentials.token` again.
+acquire a new one, see [How to manually renew](#how-to-manually-renew-expired-credentials) section.
 
 #### OIDC Auth Provider
 
@@ -329,10 +329,32 @@ If you use `Config.context(...).auth_options` and the `$KUBECONFIG` file has use
 kubeclient will automatically obtain a token (or use `id-token` if still valid)
 
 Tokens are typically short-lived (e.g. 1 hour) and the expiration time is determined by the OIDC Provider (e.g. Google).
-If your code requires authentication for longer than that you should obtain a new token periodically using `.context()`
+If your code requires authentication for longer than that you should obtain a new token periodically, see [How to manually renew](#how-to-manually-renew-expired-credentials) section.
 
 Note: id-tokens retrieved via this provider are not written back to the `$KUBECONFIG` file as they would be when
 using `kubectl`.
+
+#### How to manually renew expired credentials
+
+Kubeclient [does not yet](https://github.com/abonas/kubeclient/issues/393) help with this.
+
+The division of labor between `Config` and `Context` objects may change, for now please make no assumptions at which stage `exec:` and `auth-provider:` are handled and whether they're cached.
+The currently guaranteed way to renew is create a new `Config` object.
+
+The more painful part is that you'll then need to create new `Client` object(s) with the credentials from new config.
+So repeat all of this:
+```ruby
+config = Kubeclient::Config.read(ENV['KUBECONFIG'] || '/path/to/.kube/config')
+context = config.context
+ssl_options = context.ssl_options
+auth_options = context.auth_options
+
+client = Kubeclient::Client.new(
+    context.api_endpoint, 'v1',
+    ssl_options: ssl_options, auth_options: auth_options
+)
+# and additional Clients if needed...
+```
 
 #### Security: Don't use config from untrusted sources
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ context = config.context('default/192-168-99-100:8443/system:admin')
 
 Kubeclient::Client.new(
   context.api_endpoint,
-  context.api_version,
+  'v1',
   ssl_options: context.ssl_options,
   auth_options: context.auth_options
 )

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -130,7 +130,8 @@ class KubeclientConfigTest < MiniTest::Test
     config.context(config.contexts.first)
   end
 
-  # Each call to .context() should obtain a new token, calling .auth_options doesn't change anything
+  # Each call to .context() obtains a new token, calling .auth_options doesn't change anything.
+  # NOTE: this is not a guarantee, may change, just testing current behavior.
   def test_gcp_default_auth_renew
     Kubeclient::GoogleApplicationDefaultCredentials.expects(:token).returns('token1').once
     parsed = YAML.safe_load(File.read(config_file('gcpauth.kubeconfig')), [Date, Time])


### PR DESCRIPTION
Before I release, I want to retract the promise I added in the last commit of #394 (0cbf5db635ef084ac9b060cd3b7c1cb7ad03a322), subsequently repeated in #396.

### Motivation:
Following https://github.com/abonas/kubeclient/issues/392#issuecomment-465157309, I want to let `Config` and `Config::Context` expose the underlying data, because why not.  
Ideally for that, `Config#context` would become a passive function, and then the active work of executing `exec:` command / `auth-provider:` network calls would be delayed until you call `Config::Context#auth_options` (?)
See below why that's not as simple, but I don't want to tie my hands now.

Plus this all is likely to change with auto auth renewal (#393).  
Should figure that plan before making changes.  Maybe reserving this freedom will help there too?

@motymichaely @timothysmith0609 @jeremywadsack @rhysm, do you think this is reasonable or am I inconveniencing people?

### Why can't simply move the active work from `Config#context` to `Config::Context#auth_options`

1. `exec:` may return client certificate instead of token, and that goes into `ssl_options`.
   I think we don't support that now, but should.

2. Might be problematic change with current usage patterns:
    Users that need several `Client` objects (for different api groups), may well be doing:
    ```ruby
    context = config.context(...)  # once
    client1 = Kubeclient::Client.new(... context.auth_options, ...)
    client2 = Kubeclient::Client.new(... context.auth_options, ...)
    ```
    If I simply make `auth_options` do the work, it'll then obtain many tokens.

however, could have Context obtain auth at most once, but delayed until auth_options / ssl_options are called?