### PR TITLE
Consider OIDC tokens with an unknown kid to be expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
+### Added
+- OpenID Connect tokens which cannot be validaded because we cannot identify the key they were signed with will be considered expired and refreshed as usual. (#407)
+
 ## 4.3.0 — 2019-03-03
 
 ### Changed

--- a/test/test_oidc_auth_provider.rb
+++ b/test/test_oidc_auth_provider.rb
@@ -57,6 +57,25 @@ class OIDCAuthProviderTest < MiniTest::Test
     end
   end
 
+  def test_token_with_unknown_kid
+    OpenIDConnect::Discovery::Provider::Config.stub(:discover!, discovery_mock) do
+      OpenIDConnect::ResponseObject::IdToken.stub(
+        :decode, ->(_token, _jwks) { raise JSON::JWK::Set::KidNotFound }
+      ) do
+        OpenIDConnect::Client.stub(:new, openid_client_mock) do
+          retrieved_id_token = Kubeclient::OIDCAuthProvider.token(
+            'client-id' => @client_id,
+            'client-secret' => @client_secret,
+            'id-token' => @id_token,
+            'idp-issuer-url' => @idp_issuer_url,
+            'refresh-token' => @refresh_token
+          )
+          assert_equal(@new_id_token, retrieved_id_token)
+        end
+      end
+    end
+  end
+
   private
 
   def openid_client_mock


### PR DESCRIPTION
When the authorization server rotates key IDs, we might encounter a token with a kid which the server no longer reports in discovery. Currently, json-jwt raises an exception and the user must expend a lot of effort debugging. We can help by simply assuming the token is expired and forcing token refresh.
