### PR TITLE
Added resourceVersion to acceptable get options

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,12 @@ You can specify multiple labels (that option will return entities which have bot
 pods = client.get_pods(label_selector: 'name=redis-master,app=redis')
 ```
 
+You can get entities at a specific version by specifying a parameter named `resource_version` (named `resourceVersion` in Kubernetes server):
+
+```ruby
+pods = client.get_pods(resource_version: '0')
+```
+
 Get all entities of a specific type in chunks:
 
 ```ruby

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -39,7 +39,7 @@ module Kubeclient
     SEARCH_ARGUMENTS = {
       'labelSelector'   => :label_selector,
       'fieldSelector'   => :field_selector,
-      'resourceVersion' => :resource_version
+      'resourceVersion' => :resource_version,
       'limit'           => :limit,
       'continue'        => :continue
     }.freeze

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -37,10 +37,11 @@ module Kubeclient
     DEFAULT_HTTP_MAX_REDIRECTS = 10
 
     SEARCH_ARGUMENTS = {
-      'labelSelector' => :label_selector,
-      'fieldSelector' => :field_selector,
-      'limit'         => :limit,
-      'continue'      => :continue
+      'labelSelector'   => :label_selector,
+      'fieldSelector'   => :field_selector,
+      'resourceVersion' => :resource_version
+      'limit'           => :limit,
+      'continue'        => :continue
     }.freeze
 
     WATCH_ARGUMENTS = {

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -296,6 +296,22 @@ class KubeclientTest < MiniTest::Test
     )
   end
 
+  def test_entities_with_resource_version
+    version = '329'
+
+    stub_core_api_list
+    stub_get_services
+
+    services = client.get_services(resource_version: version)
+
+    assert_instance_of(Kubeclient::Common::EntityList, services)
+    assert_requested(
+      :get,
+      "http://localhost:8080/api/v1/services?resourceVersion=#{version}",
+      times: 1
+    )
+  end
+
   def test_entities_with_field_selector
     selector = 'involvedObject.name=redis-master'
 


### PR DESCRIPTION
ResourceVersion is useful to continue a previous get, and making it 0 forces a local api server request instead of an etcd fetch, which is more efficient.