### PR TITLE
Remove padding from Base64 token in AmazonEksCredentials

### DIFF
--- a/lib/kubeclient/aws_eks_credentials.rb
+++ b/lib/kubeclient/aws_eks_credentials.rb
@@ -38,7 +38,7 @@ module Kubeclient
             'X-K8s-Aws-Id' => eks_cluster
           }
         )
-        kube_token = 'k8s-aws-v1.' + Base64.urlsafe_encode64(presigned_url_string.to_s).sub(/=(.*)?/, '') # rubocop:disable Metrics/LineLength
+        kube_token = 'k8s-aws-v1.' + Base64.urlsafe_encode64(presigned_url_string.to_s).sub(/=*$/, '') # rubocop:disable Metrics/LineLength
         kube_token
       end
     end

--- a/lib/kubeclient/aws_eks_credentials.rb
+++ b/lib/kubeclient/aws_eks_credentials.rb
@@ -38,7 +38,7 @@ module Kubeclient
             'X-K8s-Aws-Id' => eks_cluster
           }
         )
-        kube_token = 'k8s-aws-v1.' + Base64.urlsafe_encode64(presigned_url_string.to_s).chomp('==')
+        kube_token = 'k8s-aws-v1.' + Base64.urlsafe_encode64(presigned_url_string.to_s).sub(/=(.*)?/,'')
         kube_token
       end
     end

--- a/lib/kubeclient/aws_eks_credentials.rb
+++ b/lib/kubeclient/aws_eks_credentials.rb
@@ -38,7 +38,7 @@ module Kubeclient
             'X-K8s-Aws-Id' => eks_cluster
           }
         )
-        kube_token = 'k8s-aws-v1.' + Base64.urlsafe_encode64(presigned_url_string.to_s).sub(/=(.*)?/,'')
+        kube_token = 'k8s-aws-v1.' + Base64.urlsafe_encode64(presigned_url_string.to_s).sub(/=(.*)?/, '') # rubocop:disable Metrics/LineLength
         kube_token
       end
     end


### PR DESCRIPTION
The Base64 encoding of the signature request sometimes comes back with 1 or 2 equal signs (or 'padding' - https://parsiya.net/blog/2017-08-06-tldr-base64/#padding).  This change should be safe as the '=' is only for padding and is safe to remove.