### PR TITLE
make using watcher easier/safer by passing a block directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,8 +596,7 @@ client.all_entities
 It is possible to receive live update notices watching the relevant entities:
 
 ```ruby
-watcher = client.watch_pods
-watcher.each do |notice|
+client.watch_pods do |notice|
   # process notice data
 end
 ```
@@ -605,15 +604,19 @@ end
 It is possible to interrupt the watcher from another thread with:
 
 ```ruby
-watcher.finish
+watcher = client.watch_pods
+watcher.each do |notice|
+  # process notice data
+end
+
+watcher.finish # other thread
 ```
 
 #### Watch events for a particular object
 You can use the `field_selector` option as part of the watch methods.
 
 ```ruby
-watcher = client.watch_events(namespace: 'development', field_selector: 'involvedObject.name=redis-master')
-watcher.each do |notice|
+client.watch_events(namespace: 'development', field_selector: 'involvedObject.name=redis-master') do |notice|
   # process notice date
 end
 ```
@@ -673,8 +676,7 @@ client.get_pod_log('pod-name', 'default', tail_lines: 10)
 You can also watch the logs of a pod to get a stream of data:
 
 ```ruby
-watcher = client.watch_pod_log('pod-name', 'default', container: 'ruby')
-watcher.each do |line|
+client.watch_pod_log('pod-name', 'default', container: 'ruby') do |line|
   puts line
 end
 ```

--- a/test/test_pod_log.rb
+++ b/test/test_pod_log.rb
@@ -70,11 +70,11 @@ class TestPodLog < MiniTest::Test
   end
 
   def test_watch_pod_log
-    expected_lines = open_test_file('pod_log.txt').read.split("\n")
+    file = open_test_file('pod_log.txt')
+    expected_lines = file.read.split("\n")
 
     stub_request(:get, %r{/namespaces/default/pods/[a-z0-9-]+/log\?.*follow})
-      .to_return(body: open_test_file('pod_log.txt'),
-                 status: 200)
+      .to_return(body: file, status: 200)
 
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
 
@@ -82,6 +82,21 @@ class TestPodLog < MiniTest::Test
     stream.to_enum.with_index do |notice, index|
       assert_instance_of(String, notice)
       assert_equal(expected_lines[index], notice)
+    end
+  end
+
+  def test_watch_pod_log_with_block
+    file = open_test_file('pod_log.txt')
+    first = file.readlines.first.chomp
+
+    stub_request(:get, %r{/namespaces/default/pods/[a-z0-9-]+/log\?.*follow})
+      .to_return(body: file, status: 200)
+
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+
+    client.watch_pod_log('redis-master-pod', 'default') do |line|
+      assert_equal first, line
+      break
     end
   end
 

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -27,6 +27,19 @@ class TestWatch < MiniTest::Test
     end
   end
 
+  def test_watch_pod_block
+    stub_core_api_list
+    stub_request(:get, %r{/watch/pods})
+      .to_return(body: open_test_file('watch_stream.json'),
+                 status: 200)
+
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+    yielded = []
+    client.watch_pods { |notice| yielded << notice.type }
+
+    assert_equal %w[ADDED MODIFIED DELETED], yielded
+  end
+
   def test_watch_pod_raw
     stub_core_api_list
 


### PR DESCRIPTION
I just want to do this ... having to know about watcher is unnecessary overhead and it not automatically closing itself is trouble some too, so make it simple to do the right thing:

```ruby
watch_nodes do |node|
```

/cc @cben 