### PR TITLE
Support limitBytes query parameter for get_pod_log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
   exclude:
     - os: osx
       rvm: "2.2.0"
+    - os: osx
+      rvm: "2.3.0"
   include:
     - os: linux
       rvm: "2.5.0"

--- a/README.md
+++ b/README.md
@@ -673,6 +673,12 @@ client.get_pod_log('pod-name', 'default', tail_lines: 10)
 # => "..."
 ```
 
+Kubernetes can fetch a specific number of bytes from the log, but the exact size is not guaranteed and last line may not be terminated:
+```ruby
+client.get_pod_log('pod-name', 'default', limit_bytes: 10)
+# => "..."
+```
+
 You can also watch the logs of a pod to get a stream of data:
 
 ```ruby

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -427,13 +427,14 @@ module Kubeclient
 
     def get_pod_log(pod_name, namespace,
                     container: nil, previous: false,
-                    timestamps: false, since_time: nil, tail_lines: nil)
+                    timestamps: false, since_time: nil, tail_lines: nil, limit_bytes: nil)
       params = {}
       params[:previous] = true if previous
       params[:container] = container if container
       params[:timestamps] = timestamps if timestamps
       params[:sinceTime] = format_datetime(since_time) if since_time
       params[:tailLines] = tail_lines if tail_lines
+      params[:limitBytes] = limit_bytes if limit_bytes
 
       ns = build_namespace_prefix(namespace)
       handle_exception do

--- a/test/test_pod_log.rb
+++ b/test/test_pod_log.rb
@@ -69,6 +69,25 @@ class TestPodLog < MiniTest::Test
                      times: 1)
   end
 
+  def test_get_pod_limit_bytes
+    selected_bytes = open_test_file('pod_log.txt').read(10)
+
+    stub_request(:get, %r{/namespaces/default/pods/[a-z0-9-]+/log})
+      .to_return(body: selected_bytes,
+                 status: 200)
+
+    client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
+    retrieved_log = client.get_pod_log('redis-master-pod',
+                                       'default',
+                                       limit_bytes: 10)
+
+    assert_equal(selected_bytes, retrieved_log)
+
+    assert_requested(:get,
+                     'http://localhost:8080/api/v1/namespaces/default/pods/redis-master-pod/log?limitBytes=10',
+                     times: 1)
+  end
+
   def test_watch_pod_log
     file = open_test_file('pod_log.txt')
     expected_lines = file.read.split("\n")


### PR DESCRIPTION
some log lines could be really long and produce more data than a
ruby application is willing to process. Adding `limit_bytes` as a
parameter to `get_pod_log` will help protect against large sized
logs.