### PR TITLE
fix Ruby 2.7 deprecation warnings

### DIFF
--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -28,7 +28,7 @@ module Kubeclient
         uri,
         '/api',
         version,
-        options
+        **options
       )
     end
   end

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -229,7 +229,7 @@ module Kubeclient
 
         define_singleton_method("delete_#{entity.method_names[0]}") \
         do |name, namespace = nil, opts = {}|
-          delete_entity(entity.resource_name, name, namespace, opts)
+          delete_entity(entity.resource_name, name, namespace, **opts)
         end
 
         define_singleton_method("create_#{entity.method_names[0]}") do |entity_config|


### PR DESCRIPTION
Example:
```
…/gems/kubeclient-4.6.0/lib/kubeclient.rb:27: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
…/gems/kubeclient-4.6.0/lib/kubeclient/common.rb:61: warning: The called method `initialize_client' is defined here
```

I have not setup the CI locally, so let's see if this passes. 