### PR TITLE
bump recursive-open-struct for Ruby 2.7 compatibility

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'jsonpath', '~> 1.0'
 
   spec.add_dependency 'rest-client', '~> 2.0'
-  spec.add_dependency 'recursive-open-struct', '~> 1.0', '>= 1.0.4'
+  spec.add_dependency 'recursive-open-struct', '~> 1.1', '>= 1.1.1'
   spec.add_dependency 'http', '>= 3.0', '< 5.0'
 end


### PR DESCRIPTION
1.1.1 adds support for 2.7 while keeping support for older Rubies,
cmp. https://github.com/aetherknight/recursive-open-struct/pull/64#issuecomment-597469281