### PR TITLE
Add userinfo.email to default scopes in gcp auth provider

### DIFF
--- a/lib/kubeclient/google_application_default_credentials.rb
+++ b/lib/kubeclient/google_application_default_credentials.rb
@@ -16,7 +16,12 @@ module Kubeclient
                 'googleauth gem. To support auth-provider gcp, you must include it in your ' \
                 "calling application. Failed with: #{e.message}"
         end
-        scopes = ['https://www.googleapis.com/auth/cloud-platform']
+
+        scopes = [
+          'https://www.googleapis.com/auth/cloud-platform',
+          'https://www.googleapis.com/auth/userinfo.email'
+        ]
+
         authorization = Google::Auth.get_application_default(scopes)
         authorization.apply({})
         authorization.access_token


### PR DESCRIPTION
I was attempting to use `kubeclient` to connect to a GKE cluster by leveraging the `gcp` auth provider.

I had granted the service account access to certain resources through RBAC policies in the destination cluster yet I kept getting this error:

```
User "10345xxxxxxxxx" cannot patch resource "xxxxxxx" in API group "xxxxx"
in the namespace "xxxxx": Required "container.thirdPartyObjects.update" permission.
```

After digging into the issue, we realized the default scope for the `gcp` auth provider is missing `https://www.googleapis.com/auth/userinfo.email`.

Here's an excerpt of [`client-go`'s `gcp` auth provider](https://github.com/kubernetes/kubernetes/blob/a3ccea9d8743f2ff82e41b6c2af6dc2c41dc7b10/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go#L49-L55):

```golang
	// defaultScopes:
	// - cloud-platform is the base scope to authenticate to GCP.
	// - userinfo.email is used to authenticate to GKE APIs with gserviceaccount
	//   email instead of numeric uniqueID.
	defaultScopes = []string{
		"https://www.googleapis.com/auth/cloud-platform",
		"https://www.googleapis.com/auth/userinfo.email"}
```

There's also some clarification about this [in GCP's docs](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#authentication):

> All GKE clusters are configured to accept Google Cloud user and service account identities, by validating the credentials presented by `kubectl` and retrieving the email address associated with the user or service account identity. As a result, the credentials for those accounts must include the `userinfo.email` OAuth scope in order to successfully authenticate.

@cben as a follow-up to this PR, it might make sense to pass `config` to `GoogleApplicationDefaultCredentials.token` such that users can customize the scopes. Here's [an example from `client-go`](https://github.com/kubernetes/kubernetes/blob/a3ccea9d8743f2ff82e41b6c2af6dc2c41dc7b10/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go#L62-L75):

```golang
// {
//   'auth-provider': {
//     # Required
//     "name": "gcp",
//
//     'config': {
//       # Authentication options
//       # These options are used while getting a token.
//
//       # comma-separated list of GCP API scopes. default value of this field
//       # is "https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/userinfo.email".
// 		 # to override the API scopes, specify this field explicitly.
//       "scopes": "https://www.googleapis.com/auth/cloud-platform"
```