### PR TITLE
Release 4.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ rvm:
   - "2.3.0"
   - "2.4.0"
   - "2.5.0"
-  - "2.6.3"
+  - "2.6.0"
+  - "2.7.0"
 env:
  - TASK=test
 matrix:
@@ -20,6 +21,8 @@ matrix:
       rvm: "2.2.0"
     - os: osx
       rvm: "2.3.0"
+  # No point running Rubocop on different rubies, results will be same.
+  # The rubies it expects the code to target are controlled in .rubocop.yml.
   include:
     - os: linux
       rvm: "2.5.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
+## 4.7.0 — 2020-06-14
+
+### Fixed
+- Ruby 2.7 compatibility: bumped minimum recursive-open-struct to one that works on 2.7 (#439).
+- Ruby 2.7 warnings (#433, #438).
+- Improved watch documentation, including behavior planned to change in 5.0.0 (#436).
+
+### Added
+- Google Application Default Credentials: Added `userinfo.email` to requested scopes, which is necessary for RBAC policies (#441).
+
 ## 4.6.0 — 2019-12-30
 
 ### Fixed

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,7 +20,9 @@ Edit `CHANGELOG.md` as necessary.  Even if all included changes remembered to up
 
 Bump `lib/kubeclient/version.rb` manually, or by using:
 ```bash
-git checkout -b release-$RELEASE_VERSION
+RELEASE_VERSION=x.y.z
+
+git checkout -b "release-$RELEASE_VERSION" $RELEASE_BRANCH
 # Won't work with uncommitted changes, you have to commit the changelog first.
 gem bump --version $RELEASE_VERSION
 git show # View version bump change.

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'jsonpath', '~> 1.0'
 
   spec.add_dependency 'rest-client', '~> 2.0'
-  spec.add_dependency 'recursive-open-struct', '~> 1.0', '>= 1.0.4'
+  spec.add_dependency 'recursive-open-struct', '~> 1.1', '>= 1.1.1'
   spec.add_dependency 'http', '>= 3.0', '< 5.0'
 end

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -28,7 +28,7 @@ module Kubeclient
         uri,
         '/api',
         version,
-        options
+        **options
       )
     end
   end

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -229,7 +229,7 @@ module Kubeclient
 
         define_singleton_method("delete_#{entity.method_names[0]}") \
         do |name, namespace = nil, opts = {}|
-          delete_entity(entity.resource_name, name, namespace, opts)
+          delete_entity(entity.resource_name, name, namespace, **opts)
         end
 
         define_singleton_method("create_#{entity.method_names[0]}") do |entity_config|

--- a/lib/kubeclient/google_application_default_credentials.rb
+++ b/lib/kubeclient/google_application_default_credentials.rb
@@ -16,7 +16,12 @@ module Kubeclient
                 'googleauth gem. To support auth-provider gcp, you must include it in your ' \
                 "calling application. Failed with: #{e.message}"
         end
-        scopes = ['https://www.googleapis.com/auth/cloud-platform']
+
+        scopes = [
+          'https://www.googleapis.com/auth/cloud-platform',
+          'https://www.googleapis.com/auth/userinfo.email'
+        ]
+
         authorization = Google::Auth.get_application_default(scopes)
         authorization.apply({})
         authorization.access_token

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -1,4 +1,4 @@
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '4.6.0'.freeze
+  VERSION = '4.7.0'.freeze
 end


### PR DESCRIPTION
As I've already merged compatibility-breaking #355 into master, I can't release 4.y.z from master.  But I'm dragging 5.0 plans too long (see #435), and the Ruby 2.7 fixes are certainly worth releasing without a major bump.

=> Opened new branch `abonas/v4.y` from last release tag `v4.6.0`, this PR is onto that branch.
Backported all the changes except #355.