### PR TITLE
Declare runtime dependency on jsonpath for `gcp` provider with `cmd-path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 
 ### Added
 - Support for server-side apply (#448).
+- Declare dependency on jsonpath, needed for `gcp` provider with `cmd-path` (#450).
 
 ## 4.7.0 — 2020-06-14
 

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'googleauth', '~> 0.5.1'
   spec.add_development_dependency('mocha', '~> 1.5')
   spec.add_development_dependency 'openid_connect', '~> 1.1'
-  spec.add_development_dependency 'jsonpath', '~> 1.0'
 
+  spec.add_dependency 'jsonpath', '~> 1.0'
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'recursive-open-struct', '~> 1.1', '>= 1.1.1'
   spec.add_dependency 'http', '>= 3.0', '< 5.0'


### PR DESCRIPTION
Fixes #444
It was a implicit dependency similar to other auth provider dependencies being "optional", having users depend on them themselves if needed — except we'd never documented this! :facepalm: 