### PR TITLE
Add support for client-type ExecCredentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
+## 4.9.0 - 2020-08-03
+### Added
+- Support for `user: exec` credential plugins using TLS client auth (#453)
+
 ## 4.8.0 — 2020-07-03
 
 ### Added

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -43,7 +43,7 @@ module Kubeclient
 
       if user.key?('exec')
         exec_opts = expand_command_option(user['exec'], 'command')
-        user = ExecCredentials.run(exec_opts)
+        user['exec_result'] = ExecCredentials.run(exec_opts)
       end
 
       ca_cert_data     = fetch_cluster_ca_data(cluster)
@@ -139,8 +139,8 @@ module Kubeclient
         File.read(ext_file_path(user['client-certificate']))
       elsif user.key?('client-certificate-data')
         Base64.decode64(user['client-certificate-data'])
-      elsif user.key?('clientCertificateData')
-        user['clientCertificateData']
+      elsif user.key?('exec_result') && user['exec_result'].key?('clientCertificateData')
+        user['exec_result']['clientCertificateData']
       end
     end
 
@@ -149,8 +149,8 @@ module Kubeclient
         File.read(ext_file_path(user['client-key']))
       elsif user.key?('client-key-data')
         Base64.decode64(user['client-key-data'])
-      elsif user.key?('clientKeyData')
-        user['clientKeyData']
+      elsif user.key?('exec_result') && user['exec_result'].key?('clientKeyData')
+        user['exec_result']['clientKeyData']
       end
     end
 
@@ -158,6 +158,8 @@ module Kubeclient
       options = {}
       if user.key?('token')
         options[:bearer_token] = user['token']
+      elsif user.key?('exec_result') && user['exec_result'].key?('token')
+        options[:bearer_token] = user['exec_result']['token']
       elsif user.key?('auth-provider')
         options[:bearer_token] = fetch_token_from_provider(user['auth-provider'])
       else

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -41,6 +41,11 @@ module Kubeclient
     def context(context_name = nil)
       cluster, user, namespace = fetch_context(context_name || @kcfg['current-context'])
 
+      if user.key?('exec')
+        exec_opts = expand_command_option(user['exec'], 'command')
+        user = ExecCredentials.run(exec_opts)
+      end
+
       ca_cert_data     = fetch_cluster_ca_data(cluster)
       client_cert_data = fetch_user_cert_data(user)
       client_key_data  = fetch_user_key_data(user)
@@ -134,6 +139,8 @@ module Kubeclient
         File.read(ext_file_path(user['client-certificate']))
       elsif user.key?('client-certificate-data')
         Base64.decode64(user['client-certificate-data'])
+      elsif user.key?('clientCertificateData')
+        user['clientCertificateData']
       end
     end
 
@@ -142,6 +149,8 @@ module Kubeclient
         File.read(ext_file_path(user['client-key']))
       elsif user.key?('client-key-data')
         Base64.decode64(user['client-key-data'])
+      elsif user.key?('clientKeyData')
+        user['clientKeyData']
       end
     end
 
@@ -149,9 +158,6 @@ module Kubeclient
       options = {}
       if user.key?('token')
         options[:bearer_token] = user['token']
-      elsif user.key?('exec')
-        exec_opts = expand_command_option(user['exec'], 'command')
-        options[:bearer_token] = Kubeclient::ExecCredentials.token(exec_opts)
       elsif user.key?('auth-provider')
         options[:bearer_token] = fetch_token_from_provider(user['auth-provider'])
       else

--- a/lib/kubeclient/exec_credentials.rb
+++ b/lib/kubeclient/exec_credentials.rb
@@ -53,10 +53,15 @@ module Kubeclient
         raise 'exec plugin didn\'t return a status field' if status.nil?
 
         has_client_credentials = validate_client_credentials_status(status)
-        return if has_client_credentials
-
         has_token = status.key?('token')
-        raise 'exec plugin didn\'t return a token' unless has_token
+
+        if has_client_credentials && has_token
+          raise 'exec plugin returned both token and client data'
+        end
+
+        return if has_client_credentials || has_token
+
+        raise 'exec plugin didn\'t return a token or client data' unless has_token
       end
 
       def validate_credentials(opts, creds)

--- a/lib/kubeclient/exec_credentials.rb
+++ b/lib/kubeclient/exec_credentials.rb
@@ -6,7 +6,7 @@ module Kubeclient
   # Inspired by https://github.com/kubernetes/client-go/blob/master/plugin/pkg/client/auth/exec/exec.go
   class ExecCredentials
     class << self
-      def token(opts)
+      def run(opts)
         require 'open3'
         require 'json'
 
@@ -25,13 +25,38 @@ module Kubeclient
 
         creds = JSON.parse(out)
         validate_credentials(opts, creds)
-        creds['status']['token']
+        creds['status']
       end
 
       private
 
       def validate_opts(opts)
         raise KeyError, 'exec command is required' unless opts['command']
+      end
+
+      def validate_client_credentials_status(status)
+        has_client_cert_data = status.key?('clientCertificateData')
+        has_client_key_data = status.key?('clientKeyData')
+
+        if has_client_cert_data && !has_client_key_data
+          raise 'exec plugin didn\'t return client key data'
+        end
+
+        if !has_client_cert_data && has_client_key_data
+          raise 'exec plugin didn\'t return client certificate data'
+        end
+
+        has_client_cert_data && has_client_key_data
+      end
+
+      def validate_credentials_status(status)
+        raise 'exec plugin didn\'t return a status field' if status.nil?
+
+        has_client_credentials = validate_client_credentials_status(status)
+        return if has_client_credentials
+
+        has_token = status.key?('token')
+        raise 'exec plugin didn\'t return a token' unless has_token
       end
 
       def validate_credentials(opts, creds)
@@ -45,8 +70,7 @@ module Kubeclient
             "plugin returned version #{creds['apiVersion']}"
         end
 
-        raise 'exec plugin didn\'t return a status field' if creds['status'].nil?
-        raise 'exec plugin didn\'t return a token' if creds['status']['token'].nil?
+        validate_credentials_status(creds['status'])
       end
 
       # Transform name/value pairs to hash

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -1,4 +1,4 @@
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '4.8.0'.freeze
+  VERSION = '4.9.0'.freeze
 end

--- a/test/test_exec_credentials.rb
+++ b/test/test_exec_credentials.rb
@@ -80,6 +80,83 @@ class ExecCredentialsTest < MiniTest::Test
     end
   end
 
+  def test_run_with_missing_client_certificate_data
+    opts = { 'command' => 'dummy' }
+
+    credentials = {
+      'clientKeyData' => '0123456789ABCDEF0123456789ABCDEF'
+    }
+
+    creds = JSON.dump(
+      'apiVersion' => 'client.authentication.k8s.io/v1alpha1',
+      'status' => credentials
+    )
+
+    st = Minitest::Mock.new
+    st.expect(:success?, true)
+
+    expected_msg = 'exec plugin didn\'t return client certificate data'
+
+    Open3.stub(:capture3, [creds, nil, st]) do
+      exception = assert_raises(RuntimeError) do
+        Kubeclient::ExecCredentials.run(opts)
+      end
+      assert_equal(expected_msg, exception.message)
+    end
+  end
+
+  def test_run_with_missing_client_key_data
+    opts = { 'command' => 'dummy' }
+
+    credentials = {
+      'clientCertificateData' => '0123456789ABCDEF0123456789ABCDEF'
+    }
+
+    creds = JSON.dump(
+      'apiVersion' => 'client.authentication.k8s.io/v1alpha1',
+      'status' => credentials
+    )
+
+    st = Minitest::Mock.new
+    st.expect(:success?, true)
+
+    expected_msg = 'exec plugin didn\'t return client key data'
+
+    Open3.stub(:capture3, [creds, nil, st]) do
+      exception = assert_raises(RuntimeError) do
+        Kubeclient::ExecCredentials.run(opts)
+      end
+      assert_equal(expected_msg, exception.message)
+    end
+  end
+
+  def test_run_with_client_data_and_token
+    opts = { 'command' => 'dummy' }
+
+    credentials = {
+      'clientCertificateData' => '0123456789ABCDEF0123456789ABCDEF',
+      'clientKeyData' => '0123456789ABCDEF0123456789ABCDEF',
+      'token' => '0123456789ABCDEF0123456789ABCDEF'
+    }
+
+    creds = JSON.dump(
+      'apiVersion' => 'client.authentication.k8s.io/v1alpha1',
+      'status' => credentials
+    )
+
+    st = Minitest::Mock.new
+    st.expect(:success?, true)
+
+    expected_msg = 'exec plugin returned both token and client data'
+
+    Open3.stub(:capture3, [creds, nil, st]) do
+      exception = assert_raises(RuntimeError) do
+        Kubeclient::ExecCredentials.run(opts)
+      end
+      assert_equal(expected_msg, exception.message)
+    end
+  end
+
   def test_status_missing
     opts = { 'command' => 'dummy' }
 
@@ -109,7 +186,7 @@ class ExecCredentialsTest < MiniTest::Test
     st = Minitest::Mock.new
     st.expect(:success?, true)
 
-    expected_msg = 'exec plugin didn\'t return a token'
+    expected_msg = 'exec plugin didn\'t return a token or client data'
 
     Open3.stub(:capture3, [creds, nil, st]) do
       exception = assert_raises(RuntimeError) do


### PR DESCRIPTION
This library currently supports `token`-type ExecCredentials, but there is actually another flavor for TLS client auth. With this flavor, the `status` field includes PEM-encoded `clientKeyData` and `clientCertificateData` rather than a `token`. Reference:
- https://kubernetes.io/docs/reference/access-authn-authz/authentication/#input-and-output-formats
- https://godoc.org/k8s.io/client-go/pkg/apis/clientauthentication#ExecCredentialStatus

This PR adds support for TLS client auth while maintaining support for token ExecCredentials. To accomplish this, the credentials provided by the `status` field, regardless of flavor, are passed around as if it were a `user`.