### PR TITLE
Custom class passed for `as` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ Other formats are:
  - `:ros` (default) for `RecursiveOpenStruct`
  - `:parsed` for `JSON.parse`
  - `:parsed_symbolized` for `JSON.parse(..., symbolize_names: true)`
+ - a class of your choice (this will instantiate a new instance of that class with the raw value of the response body) 
 
 ### Watch — Receive entities updates
 

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -577,6 +577,8 @@ module Kubeclient
         else
           Kubeclient::Resource.new(result)
         end
+      when Class
+        as.new(body)
       else
         raise ArgumentError, "Unsupported format #{as.inspect}"
       end

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -262,6 +262,23 @@ class KubeclientTest < MiniTest::Test
     assert_equal %i[metadata spec status], response[:items].first.keys
   end
 
+  class ServiceList
+    attr_reader :names
+
+    def initialize(raw)
+      items = JSON.parse(raw)['items']
+      @names = items.map { |item| item['metadata']['name'] }
+    end
+  end
+
+  def test_entity_list_class
+    stub_core_api_list
+    stub_get_services
+
+    response = client.get_services(as: ServiceList)
+    assert_equal %w[kubernetes kubernetes-ro], response.names
+  end
+
   def test_entity_list_unknown
     stub_core_api_list
     stub_get_services


### PR DESCRIPTION
There are some times where it's useful to be able to pass your own domain objects around instead of a `RecursiveOpenStruct`. You could accomplish this by just letting it return `:raw` and then wrapping it later, as in:

```ruby
MyObject.new(client.get_services(as: :raw))
```

but that can get repetitive, especially if you're trying to do it over every call the client makes. This commit instead adds the ability to pass in your own class, so the equivalent from the previous example would be:

```ruby
client.get_services(as: MyObject)
```

so that you can do your own processing.