### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Adding config based on [Ruby](https://github.com/ruby/ruby/blob/fb3c711df34ef9ded92e2716da842fbe7003e92a/.editorconfig)'s config, but simplified, defaulting to 2 spaces of indentation everywhere, which seems to be the case in this repo.

Without this, my VS Code was insisting on adding 4 spaces for indentation.