### PR TITLE
bump googleauth to get rid of warnings

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'rubocop', '~> 0.68.0' # TODO: bump to 1.0
-  spec.add_development_dependency 'googleauth', '~> 0.5.1'
+  spec.add_development_dependency 'googleauth', '~> 0.5'
   spec.add_development_dependency('mocha', '~> 1.5')
   spec.add_development_dependency 'openid_connect', '~> 1.1'
 


### PR DESCRIPTION
```
vendor/bundle/ruby/2.6.0/gems/os-0.9.6/lib/os.rb:154: warning: mismatched indentations at 'end' with 'for' at 151
vendor/bundle/ruby/2.6.0/gems/os-0.9.6/lib/os.rb:158: warning: assigned but unused variable - kb
vendor/bundle/ruby/2.6.0/gems/os-0.9.6/lib/os.rb:198: warning: mismatched indentations at 'end' with 'def' at 190
vendor/bundle/ruby/2.6.0/gems/os-0.9.6/lib/os.rb:240: warning: mismatched indentations at 'end' with 'case' at 218
```