### PR TITLE
Faraday retry middleware

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,8 @@
+exit
+[FaradayMiddleware::FollowRedirects, Faraday::Response::RaiseError].inspect
+client.faraday_client.builder.handlers.inspect
+
+
+
+
+

--- a/.byebug_history
+++ b/.byebug_history
@@ -1,8 +1,0 @@
-exit
-[FaradayMiddleware::FollowRedirects, Faraday::Response::RaiseError].inspect
-client.faraday_client.builder.handlers.inspect
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ client = Kubeclient::Client.new(
 )
 ```
 
+### Middleware
+
+The Faraday HTTP client used by kubeclient allows configuration of custom middlewares. For example, you may want to add instrumentation, or add custom retry options. Kubeclient provides a hook for injecting these custom middlewares into the request/response chain, via `Client#configure_faraday(&block)`. This provides an access point to the `Faraday::Connection` object during initialization. As an example, the following code adds retry options to client requests:
+
+```ruby
+client = Kubeclient::Client.new('http://localhost:8080/api', 'v1')
+retry_options = { max: 2, interval: 0.05, interval_randomness: 0.5, backoff_factor: 2 }
+client.configure_faraday { |conn| conn.request(:retry, retry_options) }
+```
+
+For more examples and documentation, consult the [Faraday docs](https://lostisland.github.io/faraday/).
+Note that certain middlewares (e.g. `:raise_error`) are always included since Kubeclient is dependent on their behaviour to function correctly.
+
 #### Inside a Kubernetes cluster
 
 The [recommended way to locate the API server](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod) within the pod is with the `kubernetes.default.svc` DNS name, which resolves to a Service IP which in turn will be routed to an API server.

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -317,9 +317,8 @@ module Kubeclient
         if @auth_options[:username] && @auth_options[:password]
           connection.basic_auth(@auth_options[:username], @auth_options[:password])
         end
-        if block_given?
-          yield(connection)
-        else
+          # hook for adding custom faraday configuration
+          yield(connection) if block_given?
           connection.use(FaradayMiddleware::FollowRedirects, limit: @http_max_redirects)
           connection.response(:raise_error)
         end

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -99,7 +99,7 @@ module Kubeclient
       end
     end
 
-    def with_faraday_config(&block)
+    def configure_faraday(&block)
       @faraday_client = create_faraday_client(&block)
     end
 

--- a/lib/kubeclient/common.rb
+++ b/lib/kubeclient/common.rb
@@ -317,11 +317,10 @@ module Kubeclient
         if @auth_options[:username] && @auth_options[:password]
           connection.basic_auth(@auth_options[:username], @auth_options[:password])
         end
-          # hook for adding custom faraday configuration
-          yield(connection) if block_given?
-          connection.use(FaradayMiddleware::FollowRedirects, limit: @http_max_redirects)
-          connection.response(:raise_error)
-        end
+        # hook for adding custom faraday configuration
+        yield(connection) if block_given?
+        connection.use(FaradayMiddleware::FollowRedirects, limit: @http_max_redirects)
+        connection.response(:raise_error)
       end
     end
 

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -273,6 +273,20 @@ class KubeclientTest < MiniTest::Test
     assert_equal(%i[metadata spec status], response[:items].first.keys)
   end
 
+  def test_retry_options_middleware
+    retry_options = {
+      exceptions: [Faraday::ClientError],
+      only: %i[get],
+      max: 3,
+      interval: 0.05
+    }
+    Kubeclient::Client.any_instance.expects(:create_faraday_client).with do |args, kwargs|
+      refute(args)
+      assert_equal(kwargs, retry_options: retry_options)
+    end
+    Kubeclient::Client.new('http://localhost:8080/api/', 'v1', retry_options: retry_options)
+  end
+
   class ServiceList
     attr_reader :names
 

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -279,7 +279,7 @@ class KubeclientTest < MiniTest::Test
     expected_middlewares.each do |klass|
       assert(client.faraday_client.builder.handlers.include?(klass))
     end
-    client.with_faraday_config { |connection| connection.use(Faraday::Request::Retry) }
+    client.configure_faraday { |connection| connection.use(Faraday::Request::Retry) }
     expected_middlewares << Faraday::Request::Retry
     expected_middlewares.each do |klass|
       assert(client.faraday_client.builder.handlers.include?(klass))

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -276,9 +276,6 @@ class KubeclientTest < MiniTest::Test
   def test_retry_options_middleware
     retry_options = {
       exceptions: [Faraday::ClientError],
-      only: %i[get],
-      max: 3,
-      interval: 0.05
     }
     Kubeclient::Client.any_instance.expects(:create_faraday_client).with do |args, kwargs|
       refute(args)

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -275,12 +275,15 @@ class KubeclientTest < MiniTest::Test
 
   def test_custom_faraday_config_options
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
-    [FaradayMiddleware::FollowRedirects, Faraday::Response::RaiseError].each do |klass|
+    expected_middlewares = [FaradayMiddleware::FollowRedirects, Faraday::Response::RaiseError]
+    expected_middlewares.each do |klass|
       assert(client.faraday_client.builder.handlers.include?(klass))
     end
     client.with_faraday_config { |connection| connection.use(Faraday::Request::Retry) }
-    assert(client.faraday_client.builder.handlers.include?(Faraday::Request::Retry))
-    assert_equal(client.faraday_client.builder.handlers.length, 1)
+    expected_middlewares << Faraday::Request::Retry
+    expected_middlewares.each do |klass|
+      assert(client.faraday_client.builder.handlers.include?(klass))
+    end
   end
 
   class ServiceList

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -275,7 +275,7 @@ class KubeclientTest < MiniTest::Test
 
   def test_retry_options_middleware
     retry_options = {
-      exceptions: [Faraday::ClientError],
+      exceptions: [Faraday::ClientError]
     }
     Kubeclient::Client.any_instance.expects(:create_faraday_client).with do |args, kwargs|
       refute(args)


### PR DESCRIPTION
cc @cben  (it's been a while since I've played around in this repo. Hope you're doing well!)

We find ourselves rewriting retry logic around kubeclient handlers to deal with intermittent API-server unavailability and figured it would be convenient to declare retry logic inside kubeclient itself. There's definitely some discussion to be had on the actual implementation but I wanted to post my work so far to get the ball rolling.

## How it works

Expose a `retry_options` option to `Kubeclient::Client.new` that is passed into the Faraday client initializer. This is convenient because:
- It is backwards compatible
- It allows consumers to specify their own retry logic

## Discussion

I see the Faraday client is lazily instantiated at the moment, though I've proactively initialized it in order to pass in the retry options inside the client initializer. I'm tempted to always initialize it, and refactor things so that we don't need a separate Faraday client for API vs. explicit-REST requests. Alternatively, we can simply leave retry options as an instance var itself, and pass them into Faraday when necessary. An even more engineered solution might be to extract Faraday client building into its own object 🤭 

Interested to hear your thoughts