### PR TITLE
allow client to retry to avoid common api errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,3 +48,5 @@ Style/AccessorGrouping:
   EnforcedStyle: separated
 Style/NegatedIfElseCondition:
   Enabled: false
+Style/NumericPredicate:
+  EnforcedStyle: comparison

--- a/README.md
+++ b/README.md
@@ -160,6 +160,15 @@ namespace = File.read('/var/run/secrets/kubernetes.io/serviceaccount/namespace')
 ```
 You can find information about tokens in [this guide](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod) and in [this reference](http://kubernetes.io/docs/admin/authentication/).
 
+### Retries
+
+If you api servers regularly fail, configure retries:
+(client will sleep 0.1s-1s, see RETRY_BACKOFF, between each retry)
+
+```ruby
+client = Kubeclient::Client.new('http://localhost:8080/apis/batch', 'v1', retries: 3)
+```
+
 ### Non-blocking IO
 
 You can also use kubeclient with non-blocking sockets such as Celluloid::IO, see [here](https://github.com/httprb/http/wiki/Parallel-requests-with-Celluloid%3A%3AIO)

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -3,12 +3,12 @@
 require 'json'
 
 require_relative 'kubeclient/aws_eks_credentials'
+require_relative 'kubeclient/http_error'
 require_relative 'kubeclient/common'
 require_relative 'kubeclient/config'
 require_relative 'kubeclient/entity_list'
 require_relative 'kubeclient/exec_credentials'
 require_relative 'kubeclient/gcp_auth_provider'
-require_relative 'kubeclient/http_error'
 require_relative 'kubeclient/missing_kind_compatibility'
 require_relative 'kubeclient/oidc_auth_provider'
 require_relative 'kubeclient/resource'

--- a/test/test_retry.rb
+++ b/test/test_retry.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+# tests with_retries in common.rb
+class RetryTest < MiniTest::Test
+  def setup
+    @slept = []
+    client.stubs(:sleep).with { |t| @slept << t }
+    stub_core_api_list
+  end
+
+  def test_no_retry_on_success
+    request = stub_request(:get, %r{/pods}).to_return(body: '{}', status: 200)
+    assert_equal([], client.get_pods)
+    assert_equal([], @slept)
+    assert_requested(request, times: 1)
+  end
+
+  def test_no_retry_on_not_found
+    request = stub_request(:get, %r{/pods}).to_return(body: '{}', status: 404)
+    assert_raises(Kubeclient::ResourceNotFoundError) { client.get_pod('foo') }
+    assert_equal([], @slept)
+    assert_requested(request, times: 1)
+  end
+
+  def test_retry_until_success
+    request = stub_request(:get, %r{/pods}).to_return(
+      { body: '{}', status: 400 },
+      body: '{}', status: 200
+    )
+    assert_equal([], client.get_pods)
+    assert_equal([0.1], @slept)
+    assert_requested(request, times: 2)
+  end
+
+  def test_retry_until_failure
+    request = stub_request(:get, %r{/pods}).to_return({ body: '{}', status: 400 })
+    assert_raises(Kubeclient::HttpError) { client.get_pods }
+    assert_equal([0.1, 0.2, 0.4], @slept)
+    assert_requested(request, times: 4)
+  end
+
+  def test_retry_large_backoff
+    @client.instance_variable_set(:@retries, 10)
+    request = stub_request(:get, %r{/pods}).to_return({ body: '{}', status: 400 })
+    assert_raises(Kubeclient::HttpError) { client.get_pods }
+    assert_equal([0.1, 0.2, 0.4, 1, 1, 1, 1, 1, 1, 1], @slept)
+    assert_requested(request, times: 11)
+  end
+
+  private
+
+  def client
+    @client ||= Kubeclient::Client.new('http://localhost:8080/api/', 'v1', retries: 3)
+  end
+end


### PR DESCRIPTION
/cc @cben 

FY some truffle-ruby failures that look unrelated `"unknown keyword: status"`