### PR TITLE
Raise ResourceAlreadyExistsError when resource being created already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,15 @@ Default timeouts match `Net::HTTP` and `RestClient`:
 
 If you want ruby-independent behavior, always specify `:open`.
 
+### Errors
+
+If an error occurs while performing a request to the API server, `Kubeclient::HttpError` will be raised.
+
+There are also certain case-specific errors that can be raised (which also inherit from `Kubeclient::HttpError`):
+
+- `Kubeclient::ResourceNotFoundError` when attempting to fetch a resource that does not exist or any other situation that results in the API server returning a 404.
+- `Kubeclient::ResourceAlreadyExistsError` when attempting to create a resource that already exists.
+
 ### Discovery
 
 Discovery from the kube-apiserver is done lazily on method calls so it would not change behavior.

--- a/lib/kubeclient/resource_already_exists_error.rb
+++ b/lib/kubeclient/resource_already_exists_error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Kubeclient
+  class ResourceAlreadyExistsError < HttpError
+  end
+end

--- a/test/json/namespace_already_exists.json
+++ b/test/json/namespace_already_exists.json
@@ -1,0 +1,11 @@
+ {
+  "metadata": {},
+  "status": "Failure",
+  "message": "namespaces \"default\" already exists",
+  "reason": "AlreadyExists",
+  "details": {
+    "name": "default",
+    "kind": "namespaces"
+  },
+  "code": 409
+}

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -224,6 +224,18 @@ class KubeclientTest < MiniTest::Test
     assert_equal(404, exception.error_code)
   end
 
+  def test_resource_already_exists_exception
+    stub_core_api_list
+    stub_request(:post, %r{/api/v1/namespaces})
+      .to_return(body: open_test_file('namespace_already_exists.json'), status: 409)
+
+    exception = assert_raises(Kubeclient::ResourceAlreadyExistsError) do
+      client.create_namespace(Kubeclient::Resource.new(metadata: { name: 'default' }))
+    end
+
+    assert_equal(409, exception.error_code)
+  end
+
   def test_entity_list
     stub_core_api_list
     stub_get_services


### PR DESCRIPTION
👋 Hello! 😄 

### Context

We've been working on automation to setup new Kubernetes clusters and part the automation involves bootstrapping namespaces. Since this automation can sometimes fail, we try to write our tasks in a way that they are idempotent and thus retryable.

Today, if you attempt to create the same namespace twice using `kubeclient` you'll get a generic `HttpError`:

```ruby
irb(main):005:0> client.create_namespace(Kubeclient::Resource.new(metadata: { name: 'default' }))
Kubeclient::HttpError (HTTP status code 409, namespaces "default" already exists for POST https://xxx.xxx.xxx.xxx/api/v1/namespaces)
```

It's possible to extract the `reason` from this `HttpError` through the `response`, but it leads to inelegant code:

```ruby
rescue Kubeclient::HttpError => e
  response = JSON.parse(e.response.body)
  return if response["reason"] == "AlreadyExists"

  raise
end
```

### This PR

This pull request exposes a new error class (`ResourceAlreadyExistsError`) which does this heavy-lifting and turns the above code into:

```ruby
rescue Kubeclient::ResourceAlreadyExistsError
  # Resource already exists, nothing to do here
  nil
rescue Kubeclient::HttpError => e
  # ...
end
```

The change should be backwards compatible since `ResourceAlreadyExistsError` inherits from `HttpError`.