### PR TITLE
Omit test/ dir from built .gem (v4.y branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
+## UNRELEASED
+
+### Removed
+- Reduce .gem size by dropping test/ directory, it's useless at run time (#502).
+
 ## 4.9.1 — 2020-08-31
 ### Fixed
 - Now should work with apiserver deployed not at root of domain but a sub-path,

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -14,9 +14,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/abonas/kubeclient'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  git_files = `git ls-files -z`.split("\x0")
+  spec.files         = git_files.grep_v(%r{^(test|spec|features)/})
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.test_files    = []
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.2.0'
 


### PR DESCRIPTION
Closes #501.  `test_files` is deprecated.  It was causing all tests to be shipped in the .gem file, which is useless bloat (was questionable tradeoff before when rubygems supported running tests for a downloaded gem, anyway no longer supported): https://github.com/rubygems/guides/issues/90

|   | before (4.9.1) | after |
|---|-------------|-----|
| Compressed | 78KB | 33KB |
| Unpacked | 757KB | 184KB |