### PR TITLE
v4.y: Disable tests using expired TLS certs

### DIFF
--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -196,6 +196,7 @@ class KubeclientConfigTest < MiniTest::Test
       #   cp openshift.local.config/master/ca.crt           test/config/external-ca.pem
       #   cp openshift.local.config/master/admin.crt        test/config/external-cert.pem
       #   cp openshift.local.config/master/admin.key        test/config/external-key.rsa
+      skip('needs investigation')
       assert(context.ssl_options[:cert_store].verify(context.ssl_options[:client_cert]))
     else
       assert_equal(OpenSSL::SSL::VERIFY_NONE, context.ssl_options[:verify_ssl])


### PR DESCRIPTION
Backporting, was disabled on master as part of commit 03c5bfbbde4fd5678a6c6c98fbc34a953eb41dfb.

https://github.com/abonas/kubeclient/issues/483
Instructions how to renew the certs no longer work (they relied on openshift 3.x).  Anyway I'm not certain what this test actually tests (other than the openssl lib)...
One thing that _would_ be valuable to test is https://github.com/abonas/kubeclient/pull/461