### PR TITLE
Merge branch 'v4.y' back to master

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,9 +1,13 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches:
+    - '**'
+    tags:
+    - '**'
   pull_request:
-    branches: [master]
+    branches:
+    - '**'
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -28,3 +32,4 @@ jobs:
     - run: gem install rake bundler
     - run: bundle install
     - run: bundle exec rake ${{ matrix.task }}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 ### Changed
 - `Kubeclient::Client.new` now always requires an api version, use for example: `Kubeclient::Client.new(uri, 'v1')`
 
+## 4.9.2 — 2021-05-30
+
+### Added
+- Ruby 3.0 compatibility (#500, #505).
+
+### Removed
+- Reduce .gem size by dropping test/ directory, it's useless at run time (#502).
+
 ## 4.9.1 — 2020-08-31
 ### Fixed
 - Now should work with apiserver deployed not at root of domain but a sub-path,

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -14,9 +14,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/abonas/kubeclient'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  git_files = `git ls-files -z`.split("\x0")
+  spec.files         = git_files.grep_v(%r{^(test|spec|features)/})
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.test_files    = []
   spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_development_dependency 'bundler', '>= 1.6'

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -2,5 +2,5 @@
 
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '4.9.1'
+  VERSION = '4.9.2'
 end


### PR DESCRIPTION
- Forward-port #502 (Omit test/ dir from built .gem)
- github actions: run on all branches & tags
  (changes nothing immediately, what actually matters is presence of this config on the created branch/tag, but merging this to master will help future forks and maintenance branches)
- Mark some v4.9.2 backports from master as clean for future merges.

