### PR TITLE
added support for keep alive timeouts #512

### DIFF
--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -53,6 +53,7 @@ module Kubeclient
 
     DEFAULT_HTTP_PROXY_URI = nil
     DEFAULT_HTTP_MAX_REDIRECTS = 10
+    DEFAULT_KEEP_ALIVE_TIMEOUT = 60
 
     SEARCH_ARGUMENTS = {
       'labelSelector'   => :label_selector,
@@ -73,6 +74,7 @@ module Kubeclient
     attr_reader :auth_options
     attr_reader :http_proxy_uri
     attr_reader :http_max_redirects
+    attr_reader :keep_alive_timeout
     attr_reader :headers
     attr_reader :discovered
 
@@ -102,6 +104,7 @@ module Kubeclient
       timeouts: DEFAULT_TIMEOUTS,
       http_proxy_uri: DEFAULT_HTTP_PROXY_URI,
       http_max_redirects: DEFAULT_HTTP_MAX_REDIRECTS,
+      keep_alive_timeout: DEFAULT_KEEP_ALIVE_TIMEOUT,
       as: :ros
     )
       validate_auth_options(auth_options)
@@ -119,6 +122,7 @@ module Kubeclient
       @timeouts = DEFAULT_TIMEOUTS.merge(timeouts)
       @http_proxy_uri = http_proxy_uri ? http_proxy_uri.to_s : nil
       @http_max_redirects = http_max_redirects
+      @keep_alive_timeout = keep_alive_timeout
       @as = as
 
       if auth_options[:bearer_token]
@@ -718,6 +722,7 @@ module Kubeclient
         headers: @headers,
         http_proxy_uri: @http_proxy_uri,
         http_max_redirects: http_max_redirects
+        keep_alive_timeout: keep_alive_timeout
       }
 
       if uri.scheme == 'https'

--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -11,6 +11,7 @@ module Kubeclient
         @http_client = nil
         @http_options = http_options
         @http_options[:http_max_redirects] ||= Kubeclient::Client::DEFAULT_HTTP_MAX_REDIRECTS
+        @http_options[:keep_alive_timeout] = 60
         @formatter = formatter
       end
 


### PR DESCRIPTION
See #512: Fix in response to watch pods timing out and not recognizing any new notices after about 30 minutes of no new watch events. 