### PR TITLE
allow allow_watch_bookmarks param

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ You can specify multiple labels (that option will return entities which have bot
 pods = client.get_pods(label_selector: 'name=redis-master,app=redis')
 ```
 
-There is also [a limited ability to filter by *some* fields](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/).  Which fields are supported is not documented, you can try and see if you get an error...
+There is also [a ability to filter by *some* fields](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/).  Which fields are supported is not documented, you can try and see if you get an error...
 ```ruby
 client.get_pods(field_selector: 'spec.nodeName=master-0')
 ```
@@ -588,6 +588,13 @@ You can also watch a single object by specifying `name:` e.g. `client.watch_node
 Note the method name is still plural!  There is no `watch_pod`, only `watch_pods`.  The yielded "type" remains the same — watch notices, it's just they'll always refer to the same object.
 
 You can use `as:` param to control the format of the yielded notices.
+
+You can use `allow_watch_bookmarks: true` to get `BOOKMARK` events returned regularly, see [watch bookmarks](https://kubernetes.io/docs/reference/using-api/api-concepts/#watch-bookmarks)
+```ruby
+client.watch_pods allow_watch_bookmarks: true do |notice|
+  # process notice data
+end
+```
 
 #### All watches come to an end!
 

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -65,7 +65,8 @@ module Kubeclient
     WATCH_ARGUMENTS = {
       'labelSelector'   => :label_selector,
       'fieldSelector'   => :field_selector,
-      'resourceVersion' => :resource_version
+      'resourceVersion' => :resource_version,
+      'allowWatchBookmarks' => :allow_watch_bookmarks
     }.freeze
 
     attr_reader :api_endpoint


### PR DESCRIPTION
needed for [watch bookmarks](https://kubernetes.io/docs/reference/using-api/api-concepts/#watch-bookmarks)
using them to get a constant heartbeat from the watch so I can stop it if it looks dead using [heartbleed](https://github.com/grosser/heartbleed)
heartbeat comes in every 1 minute after a random initial delay (saw up to 7 minutes) ... api docs say there is no guarantee