### PR TITLE
Update the AWS STS endpoint to be regional as the method is now regional

### DIFF
--- a/lib/kubeclient/aws_eks_credentials.rb
+++ b/lib/kubeclient/aws_eks_credentials.rb
@@ -29,7 +29,7 @@ module Kubeclient
         # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Sigv4/Signer.html#presign_url-instance_method
         presigned_url_string = signer.presign_url(
           http_method: 'GET',
-          url: 'https://sts.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15',
+          url: "https://sts.#{region}.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15",
           body: '',
           credentials: credentials,
           expires_in: 60,


### PR DESCRIPTION
Required to support AWS GovCloud. 
Currently the `token` method accepts a region to create the signature for logging into an AWS Cluster, which should make it "quicker" on a regional basis.
However the AWS GovCloud partition does not / is not supported by the URL `https://sts.amazonaws.com` as AWS treats it as a totally separate entity.

This change updates the STS endpoint to match the region provided with the method.

I would be happy to change the PR to update the `token` method (even the parameters) to pass a `gov_cloud` named parameter (similar to the region one), then the original `https://sts.amazonaws.com` could be kept for speed / efficiency for end-users that do not set region and use normal AWS regions - then only set the region in the URL when using the govCloud partition?

[List of AWS STS endpoint URLs](https://docs.aws.amazon.com/general/latest/gr/sts.html)

Fixes https://github.com/abonas/kubeclient/issues/527
Follows on from https://github.com/abonas/kubeclient/pull/507