### PR TITLE
[v4.y] Add cgi gem to devel dependencies

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-rg'
   spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'vcr'
+  spec.add_development_dependency 'cgi'
   spec.add_development_dependency 'rubocop', '= 0.49.1'
   spec.add_development_dependency 'googleauth', '~> 0.5.1'
   spec.add_development_dependency('mocha', '~> 1.5')


### PR DESCRIPTION
CGI was removed from ruby 3.5 core and is available as a standalone gem.

Fixes https://github.com/ManageIQ/kubeclient/actions/runs/18524932757/job/52793370705?pr=671
```
D:/rubyinstaller-head-x64/lib/ruby/gems/3.5.0+4/gems/http-cookie-1.1.0/lib/http/cookie.rb:9: warning: CGI library is removed from Ruby 3.5. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
