### PR TITLE
[WIP] [v4.y] Drop Windows from Truffleruby testing

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os_and_command.os }}
     strategy:
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2', 'ruby-head', 'truffleruby-head' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', 'ruby-head' ]
         os_and_command:
         - os: macos-latest
           command: 'env TESTOPTS="--verbose" bundle exec rake test'
@@ -29,6 +29,9 @@ jobs:
         - os: ubuntu-latest
           ruby: '2.7'
           command: 'bundle exec rake rubocop'
+        - os: ubuntu-latest
+          ruby: 'truffleruby-head'
+          command: 'timeout --signal=TERM 3m env TESTOPTS="--verbose" test/config/update_certs_k0s.rb'
     name: ${{ matrix.os_and_command.os }} ${{ matrix.ruby }} rake ${{ matrix.os_and_command.command }}
     steps:
     - uses: actions/checkout@v4
@@ -40,4 +43,3 @@ jobs:
     - run: bundle install
     - run: ${{ matrix.os_and_command.command }}
     timeout-minutes: 10
-


### PR DESCRIPTION
Truffleruby doesn't support windows so drop it from the test matrix.

Fixes: https://github.com/ManageIQ/kubeclient/actions/runs/18524932757/job/52793370757
`Error: Error: TruffleRuby does not currently support Windows.`

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
