### PR TITLE
feat: parse kubeconfig for bearer_token_file

### DIFF
--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -173,7 +173,9 @@ module Kubeclient
 
     def fetch_user_auth_options(user)
       options = {}
-      if user.key?('token')
+      if user.key?('tokenFile')
+        options[:bearer_token_file] = user['tokenFile']
+      elsif user.key?('token')
         options[:bearer_token] = user['token']
       elsif user.key?('exec_result') && user['exec_result'].key?('token')
         options[:bearer_token] = user['exec_result']['token']

--- a/test/config/userauth.kubeconfig
+++ b/test/config/userauth.kubeconfig
@@ -12,6 +12,11 @@ contexts:
 - context:
     cluster: localhost:6443
     namespace: default
+    user: system:admin:token-file
+  name: localhost/system:admin:token-file
+- context:
+    cluster: localhost:6443
+    namespace: default
     user: system:admin:userpass
   name: localhost/system:admin:userpass
 current-context: localhost/system:admin:token
@@ -21,6 +26,9 @@ users:
 - name: system:admin:token
   user:
     token: 0123456789ABCDEF0123456789ABCDEF
+- name: system:admin:token-file
+  user:
+    tokenFile: /path/to/secret/token
 - name: system:admin:userpass
   user:
     username: admin

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -98,7 +98,9 @@ class KubeclientConfigTest < MiniTest::Test
   def test_user_token
     config = Kubeclient::Config.read(config_file('userauth.kubeconfig'))
     assert_equal(
-      ['localhost/system:admin:token', 'localhost/system:admin:userpass'],
+      ['localhost/system:admin:token',
+       'localhost/system:admin:token-file',
+       'localhost/system:admin:userpass'],
       config.contexts
     )
     context = config.context('localhost/system:admin:token')
@@ -106,10 +108,25 @@ class KubeclientConfigTest < MiniTest::Test
     assert_equal('0123456789ABCDEF0123456789ABCDEF', context.auth_options[:bearer_token])
   end
 
+  def test_user_token_file
+    config = Kubeclient::Config.read(config_file('userauth.kubeconfig'))
+    assert_equal(
+      ['localhost/system:admin:token',
+       'localhost/system:admin:token-file',
+       'localhost/system:admin:userpass'],
+      config.contexts
+    )
+    context = config.context('localhost/system:admin:token-file')
+    check_context(context, ssl: true, custom_ca: false, client_cert: false)
+    assert_equal('/path/to/secret/token', context.auth_options[:bearer_token_file])
+  end
+
   def test_user_password
     config = Kubeclient::Config.read(config_file('userauth.kubeconfig'))
     assert_equal(
-      ['localhost/system:admin:token', 'localhost/system:admin:userpass'],
+      ['localhost/system:admin:token',
+       'localhost/system:admin:token-file',
+       'localhost/system:admin:userpass'],
       config.contexts
     )
     context = config.context('localhost/system:admin:userpass')


### PR DESCRIPTION
As an user of the kubeclient gem
I want to configure my Kubeconfig::Client automatically to use a tokenFile from kubeconfig
So that my token is automatically refreshed and my client does not expire.

This PR adds parsing for [tokenFile in the kubeconfig authinfo](https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/#AuthInfo) and automatically sets `auth_config[:bearer_token_file]`  in the client library. tokenFile will be prioritary over token entries if both are found.

This feature makes the existing support for bearer_token_file (which allows for refreshing tokens) in this library easier to use.
