### PR TITLE
Support http gem 6.0

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.15.0'
   spec.add_development_dependency 'minitest-rg'
   spec.add_development_dependency 'mutex_m', '~> 0.3'
-  spec.add_development_dependency 'webmock', '~> 3.0'
+  spec.add_development_dependency 'webmock', '>= 3.26.2', '< 4.0'
   spec.add_development_dependency 'rubocop', '~> 1.3.0' # locked to minor so new cops don't slip in
   spec.add_development_dependency 'googleauth', '~> 1.3'
   spec.add_development_dependency('mocha', '~> 1.5')
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '>= 1.1', '< 3.0'
   spec.add_dependency 'faraday-follow_redirects', '>= 0.3.0'
   spec.add_dependency 'recursive-open-struct', '>= 1.1.1', '< 3.0'
-  spec.add_dependency 'http', '>= 3.0', '< 6.0'
+  spec.add_dependency 'http', '>= 3.0', '< 7.0'
 end

--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -18,7 +18,11 @@ module Kubeclient
         @finished = false
 
         @http_client = build_client
-        response = @http_client.request(:get, @uri, build_client_options)
+        response = if HTTP::VERSION >= '6'
+                     @http_client.request(:get, @uri, **build_client_options)
+                   else
+                     @http_client.request(:get, @uri, build_client_options)
+                   end
         unless response.code < 300
           raise Kubeclient::HttpError.new(response.code, response.reason, response)
         end


### PR DESCRIPTION
This adds support for v6 of the `http` gem, which [switched from positional Hash arguments to keyword arguments across its public API](https://github.com/httprb/http/blob/main/UPGRADING.md).

This patch maintains support for earlier version of the `http` gem, going back to 3.0. If you’d prefer, I could modify this patch to only support v6, but that would impose a minimum Ruby version dependency of >= 3.2 on `kubeclient`.