### PR TITLE
Allow minitest 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-        - '3.1'
         - '3.2'
         - '3.3'
         - '3.4'
+        - '4.0'
         - ruby-head
         - truffleruby-head
         gemfile:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7 # Oldest version kubeclient supports
+  TargetRubyVersion: 3.0 # Oldest version kubeclient supports
   NewCops: enable
 Metrics/MethodLength:
   Enabled: false

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -18,17 +18,18 @@ Gem::Specification.new do |spec|
   spec.files         = git_files.grep_v(%r{^(test|spec|features)/})
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = []
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.0.0'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'minitest', '~> 5.15.0'
+  spec.add_development_dependency 'minitest', '~> 6.0'
+  spec.add_development_dependency 'minitest-mock'
   spec.add_development_dependency 'minitest-rg'
   spec.add_development_dependency 'mutex_m', '~> 0.3'
   spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.3.0' # locked to minor so new cops don't slip in
   spec.add_development_dependency 'googleauth', '~> 1.3'
-  spec.add_development_dependency('mocha', '~> 1.5')
+  spec.add_development_dependency('mocha', '~> 2.0')
   spec.add_development_dependency 'openid_connect', '~> 1.1'
   spec.add_development_dependency 'net-smtp'
   spec.add_development_dependency 'forking_test_runner'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,6 +2,7 @@
 
 require 'bundler/setup'
 require 'minitest/autorun'
+require 'minitest/mock'
 require 'minitest/rg'
 require 'webmock/minitest'
 require 'mocha/minitest'
@@ -10,7 +11,7 @@ require_relative '../lib/kubeclient'
 
 Thread.abort_on_exception = true
 
-MiniTest::Test.class_eval do
+Minitest::Test.class_eval do
   # Assumes test files will be in a subdirectory with the same name as the
   # file suffix.  e.g. a file named foo.json would be a "json" subdirectory.
   def open_test_file(name)

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # Unit tests for the common module
-class CommonTest < MiniTest::Test
+class CommonTest < Minitest::Test
   class ClientStub < Kubeclient::Client
   end
 

--- a/test/test_common_url_handling.rb
+++ b/test/test_common_url_handling.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # URLHandling tests
-class TestCommonUrlHandling < MiniTest::Test
+class TestCommonUrlHandling < Minitest::Test
   def test_no_path_in_uri
     client = Kubeclient::Client.new('http://localhost:8080', 'v1')
     faraday_client = client.faraday_client

--- a/test/test_component_status.rb
+++ b/test/test_component_status.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # ComponentStatus tests
-class TestComponentStatus < MiniTest::Test
+class TestComponentStatus < Minitest::Test
   def test_get_from_json_v3
     stub_core_api_list
     stub_request(:get, %r{/componentstatuses})

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -7,7 +7,7 @@ require 'open3'
 require 'openid_connect' # TODO: find out why removing tis makes the test fail when run on it's own
 
 # Testing Kubernetes client configuration
-class KubeclientConfigTest < MiniTest::Test
+class KubeclientConfigTest < Minitest::Test
   def test_allinone
     config = Kubeclient::Config.read(config_file('allinone.kubeconfig'))
     assert_equal(['Default'], config.contexts)

--- a/test/test_endpoint.rb
+++ b/test/test_endpoint.rb
@@ -6,7 +6,7 @@ require_relative 'helper'
 # This is one of the unusual `kind`s that are already plural (https://github.com/kubernetes/kubernetes/issues/8115).
 # We force singular in method names like 'create_endpoint',
 # but `kind` should remain plural as in kubernetes.
-class TestEndpoint < MiniTest::Test
+class TestEndpoint < Minitest::Test
   def test_create_endpoint
     stub_core_api_list
     testing_ep = Kubeclient::Resource.new

--- a/test/test_exec_credentials.rb
+++ b/test/test_exec_credentials.rb
@@ -4,7 +4,7 @@ require_relative 'helper'
 require 'open3'
 
 # Unit tests for the ExecCredentials provider
-class ExecCredentialsTest < MiniTest::Test
+class ExecCredentialsTest < Minitest::Test
   def test_exec_opts_missing
     expected_msg =
       'exec options are required'

--- a/test/test_gcp_command_credentials.rb
+++ b/test/test_gcp_command_credentials.rb
@@ -4,7 +4,7 @@ require_relative 'helper'
 require 'open3'
 
 # Unit tests for the GCPCommandCredentials token provider
-class GCPCommandCredentialsTest < MiniTest::Test
+class GCPCommandCredentialsTest < Minitest::Test
   def test_token
     opts = {
       'cmd-args' => 'config config-helper --format=json',

--- a/test/test_google_application_default_credentials.rb
+++ b/test/test_google_application_default_credentials.rb
@@ -4,7 +4,7 @@ require_relative 'helper'
 require 'googleauth'
 
 # Unit tests for the ApplicationDefaultCredentials token provider
-class GoogleApplicationDefaultCredentialsTest < MiniTest::Test
+class GoogleApplicationDefaultCredentialsTest < Minitest::Test
   def test_token
     auth = Minitest::Mock.new
     auth.expect(:apply, nil, [{}])

--- a/test/test_informer.rb
+++ b/test/test_informer.rb
@@ -4,7 +4,7 @@ require_relative 'helper'
 require 'stringio'
 require 'logger'
 
-class TestInformer < MiniTest::Test
+class TestInformer < Minitest::Test
   def setup
     super
     skip if RUBY_ENGINE == 'truffleruby' # TODO: race condition in truffle-ruby fails random tests

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # Kubernetes client entity tests
-class KubeclientTest < MiniTest::Test
+class KubeclientTest < Minitest::Test
   class TestFaradayMiddleware # rubocop:disable Lint/EmptyClass:
   end
 

--- a/test/test_limit_range.rb
+++ b/test/test_limit_range.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # LimitRange tests
-class TestLimitRange < MiniTest::Test
+class TestLimitRange < Minitest::Test
   def test_get_from_json_v1
     stub_core_api_list
     stub_request(:get, %r{/limitranges})

--- a/test/test_missing_methods.rb
+++ b/test/test_missing_methods.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # Test method_missing, respond_to? and respond_to_missing behaviour
-class TestMissingMethods < MiniTest::Test
+class TestMissingMethods < Minitest::Test
   def test_missing
     stub_core_api_list
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')

--- a/test/test_namespace.rb
+++ b/test/test_namespace.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # Namespace entity tests
-class TestNamespace < MiniTest::Test
+class TestNamespace < Minitest::Test
   def test_get_namespace_v1
     stub_core_api_list
     stub_request(:get, %r{/namespaces})

--- a/test/test_node.rb
+++ b/test/test_node.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # Node entity tests
-class TestNode < MiniTest::Test
+class TestNode < Minitest::Test
   def test_get_from_json_v1
     stub_core_api_list
     stub_request(:get, %r{/nodes})

--- a/test/test_oidc_auth_provider.rb
+++ b/test/test_oidc_auth_provider.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 require 'openid_connect'
 
-class OIDCAuthProviderTest < MiniTest::Test
+class OIDCAuthProviderTest < Minitest::Test
   def setup
     super()
     @client_id = 'client_id'

--- a/test/test_persistent_volume.rb
+++ b/test/test_persistent_volume.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # PersistentVolume tests
-class TestPersistentVolume < MiniTest::Test
+class TestPersistentVolume < Minitest::Test
   def test_get_from_json_v1
     stub_core_api_list
     stub_request(:get, %r{/persistentvolumes})

--- a/test/test_persistent_volume_claim.rb
+++ b/test/test_persistent_volume_claim.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # PersistentVolumeClaim tests
-class TestPersistentVolumeClaim < MiniTest::Test
+class TestPersistentVolumeClaim < Minitest::Test
   def test_get_from_json_v1
     stub_core_api_list
     stub_request(:get, %r{/persistentvolumeclaims})

--- a/test/test_pod.rb
+++ b/test/test_pod.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # Pod entity tests
-class TestPod < MiniTest::Test
+class TestPod < Minitest::Test
   def test_get_from_json_v1
     stub_core_api_list
     stub_request(:get, %r{/pods})

--- a/test/test_pod_log.rb
+++ b/test/test_pod_log.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # Pod log tests
-class TestPodLog < MiniTest::Test
+class TestPodLog < Minitest::Test
   def test_get_pod_log
     stub_request(:get, %r{/namespaces/default/pods/[a-z0-9-]+/log})
       .to_return(body: open_test_file('pod_log.txt'), status: 200)

--- a/test/test_process_template.rb
+++ b/test/test_process_template.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # Process Template tests
-class TestProcessTemplate < MiniTest::Test
+class TestProcessTemplate < Minitest::Test
   def test_process_template
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
     template = {}

--- a/test/test_real_cluster.rb
+++ b/test/test_real_cluster.rb
@@ -1,6 +1,6 @@
 require_relative 'helper'
 
-class KubeclientRealClusterTest < MiniTest::Test
+class KubeclientRealClusterTest < Minitest::Test
   # Tests here actually connect to a cluster!
   # For simplicity, these tests use same config/*.kubeconfig files as test_config.rb,
   # so are intended to run from config/update_certs_k0s.rb script.

--- a/test/test_replication_controller.rb
+++ b/test/test_replication_controller.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # Replication Controller entity tests
-class TestReplicationController < MiniTest::Test
+class TestReplicationController < Minitest::Test
   def test_get_from_json_v1
     stub_core_api_list
     stub_request(:get, %r{/replicationcontrollers})

--- a/test/test_resource_list_without_kind.rb
+++ b/test/test_resource_list_without_kind.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # Core api resource list without kind tests
-class TestResourceListWithoutKind < MiniTest::Test
+class TestResourceListWithoutKind < Minitest::Test
   def test_get_from_json_api_v1
     stub_request(:get, %r{/api/v1$})
       .to_return(body: open_test_file('core_api_resource_list_without_kind.json'), status: 200)

--- a/test/test_resource_quota.rb
+++ b/test/test_resource_quota.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # ResourceQuota tests
-class TestResourceQuota < MiniTest::Test
+class TestResourceQuota < Minitest::Test
   def test_get_from_json_v1
     stub_core_api_list
     stub_request(:get, %r{/resourcequotas})

--- a/test/test_secret.rb
+++ b/test/test_secret.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # Namespace entity tests
-class TestSecret < MiniTest::Test
+class TestSecret < Minitest::Test
   def test_get_secret_v1
     stub_core_api_list
     stub_request(:get, %r{/secrets})

--- a/test/test_security_context_constraint.rb
+++ b/test/test_security_context_constraint.rb
@@ -6,7 +6,7 @@ require_relative 'helper'
 # This is one of the unusual `kind`s that are already plural (https://github.com/kubernetes/kubernetes/issues/8115).
 # We force singular in method names like 'create_endpoint',
 # but `kind` should remain plural as in kubernetes.
-class TestSecurityContextConstraints < MiniTest::Test
+class TestSecurityContextConstraints < Minitest::Test
   def test_create_security_context_constraint
     stub_request(:get, %r{/apis/security.openshift.io/v1$}).to_return(
       body: open_test_file('security.openshift.io_api_resource_list.json'),

--- a/test/test_service.rb
+++ b/test/test_service.rb
@@ -4,7 +4,7 @@ require_relative 'helper'
 require 'openid_connect' # TODO: find out why removing tis makes the test fail when run on it's own
 
 # Service entity tests
-class TestService < MiniTest::Test
+class TestService < Minitest::Test
   def test_construct_our_own_service
     our_service = Kubeclient::Resource.new
     our_service.metadata = {}

--- a/test/test_service_account.rb
+++ b/test/test_service_account.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # ServiceAccount tests
-class TestServiceAccount < MiniTest::Test
+class TestServiceAccount < Minitest::Test
   def test_get_from_json_v1
     stub_core_api_list
     stub_request(:get, %r{/serviceaccounts})

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -3,7 +3,7 @@
 require_relative 'helper'
 
 # Watch entity tests
-class TestWatch < MiniTest::Test
+class TestWatch < Minitest::Test
   def test_watch_pod_success
     stub_core_api_list
 


### PR DESCRIPTION
Ruby 4 requires a newer minitest which also adds v3.2 as a minimum ruby requirement.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
